### PR TITLE
feat: restore `InitializeAccount3` instruction

### DIFF
--- a/program/src/token2022/mod.rs
+++ b/program/src/token2022/mod.rs
@@ -1,3 +1,6 @@
+pub mod initialize_account_3;
+pub use initialize_account_3::*;
+
 pub mod initialize_mint_close_authority;
 pub use initialize_mint_close_authority::*;
 


### PR DESCRIPTION
i came across your pinocchio realization of the CPI client to `token2022 program` and just restored the instruction.

in case you doesn't need it - just close the MR with removing `initialize_account_3.rs` from the source code.

Also, what do you think about moving this CPI client under the `pinocchio` repo?
