### PR TITLE
Feat: decouple authority and payer for resize and delete instructions

### DIFF
--- a/codama.ts
+++ b/codama.ts
@@ -394,6 +394,12 @@ const root = rootNode(
                         docs: ["Record owner or class authority for permissioned classes"]
                     }),
                     instructionAccountNode({
+                        name: "payer",
+                        isSigner: true,
+                        isWritable: true,
+                        docs: ["Account that will pay of get refunded for the record update"]
+                    }),
+                    instructionAccountNode({
                         name: "record",
                         isSigner: false,
                         isWritable: true,

--- a/codama.ts
+++ b/codama.ts
@@ -156,6 +156,12 @@ const root = rootNode(
                         docs: ["Authority used to update a class"]
                     }),
                     instructionAccountNode({
+                        name: "payer",
+                        isSigner: true,
+                        isWritable: true,
+                        docs: ["Account that will pay of get refunded for the class update"]
+                    }),
+                    instructionAccountNode({
                         name: "class",
                         isSigner: false,
                         isWritable: true,
@@ -339,6 +345,12 @@ const root = rootNode(
                         docs: ["Record owner or class authority for permissioned classes"]
                     }),
                     instructionAccountNode({
+                        name: "payer",
+                        isSigner: true,
+                        isWritable: true,
+                        docs: ["Account that will pay of get refunded for the record update"]
+                    }),
+                    instructionAccountNode({
                         name: "record",
                         isSigner: false,
                         isWritable: true,
@@ -458,6 +470,12 @@ const root = rootNode(
                         isSigner: true,
                         isWritable: true,
                         docs: ["Record owner or class authority for permissioned classes"]
+                    }),
+                    instructionAccountNode({
+                        name: "payer",
+                        isSigner: true,
+                        isWritable: true,
+                        docs: ["Account that will get refunded for the record deletion"]
                     }),
                     instructionAccountNode({
                         name: "record",
@@ -729,6 +747,12 @@ const root = rootNode(
                         isSigner: true,
                         isWritable: true,
                         docs: ["Record owner or class authority for permissioned classes"]
+                    }),
+                    instructionAccountNode({
+                        name: "payer",
+                        isSigner: true,
+                        isWritable: true,
+                        docs: ["Account that will get refunded for the tokenized record burn"]
                     }),
                     instructionAccountNode({
                         name: "mint",

--- a/program/src/constants.rs
+++ b/program/src/constants.rs
@@ -3,3 +3,5 @@ pub const MAX_NAME_LEN: usize = 0x20;
 pub const MAX_METADATA_LEN: usize = 0xff;
 pub const SRS_TICKER: &str = "SRS";
 pub const CLOSE_ACCOUNT_DISCRIMINATOR: u8 = 0xff;
+
+pub const ONE_LAMPORT_RENT: u64 = 897840;

--- a/program/src/instructions/burn_tokenized_record.rs
+++ b/program/src/instructions/burn_tokenized_record.rs
@@ -22,6 +22,7 @@ use pinocchio::{
 ///
 /// # Accounts
 /// 1. `authority` - The account that has permission to burn the record token (must be a signer)
+/// 2. `payer` - The account that will pay for the record account
 /// 2. `mint` - The mint account of the record token
 /// 3. `token_account` - The token account of the record token
 /// 4. `record` - The record account to be deleted
@@ -34,6 +35,7 @@ use pinocchio::{
 ///    b. if the class is permissioned, the authority must be the permissioned authority
 pub struct BurnTokenizedRecordAccounts<'info> {
     authority: &'info AccountInfo,
+    payer: &'info AccountInfo,
     record: &'info AccountInfo,
     mint: &'info AccountInfo,
     token_account: &'info AccountInfo,
@@ -43,7 +45,7 @@ impl<'info> TryFrom<&'info [AccountInfo]> for BurnTokenizedRecordAccounts<'info>
     type Error = ProgramError;
 
     fn try_from(accounts: &'info [AccountInfo]) -> Result<Self, Self::Error> {
-        let [authority, mint, token_account, record, _token_2022_program, rest @ ..] = accounts
+        let [authority, payer, mint, token_account, record, _token_2022_program, rest @ ..] = accounts
         else {
             return Err(ProgramError::NotEnoughAccountKeys);
         };
@@ -59,6 +61,7 @@ impl<'info> TryFrom<&'info [AccountInfo]> for BurnTokenizedRecordAccounts<'info>
 
         Ok(Self {
             authority,
+            payer,
             record,
             mint,
             token_account,
@@ -116,7 +119,7 @@ impl<'info> BurnTokenizedRecord<'info> {
         // Close the mint account
         CloseAccount {
             account: self.accounts.mint,
-            destination: self.accounts.authority,
+            destination: self.accounts.payer,
             authority: self.accounts.mint,
         }
         .invoke_signed(&signers)?;

--- a/program/src/instructions/update_record.rs
+++ b/program/src/instructions/update_record.rs
@@ -58,7 +58,7 @@ pub struct UpdateRecord<'info> {
 impl<'info> TryFrom<Context<'info>> for UpdateRecord<'info> {
     type Error = ProgramError;
 
-    fn try_from(ctx: Context<'info>) -> Result<Self, Self::Error> {
+    fn try_from(ctx: Context<'info>) -> Result<Self, Self::Error> {        
         // Deserialize our accounts array
         let accounts = UpdateRecordAccounts::try_from(ctx.accounts)?;
 

--- a/program/src/instructions/update_record.rs
+++ b/program/src/instructions/update_record.rs
@@ -15,15 +15,16 @@ use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramR
 ///
 /// # Accounts
 /// 1. `authority` - The account that has permission to update the record (must be a signer)
-/// 2. `record` - The record account to be updated
-/// 3. `system_program` - Required for account resizing operations
-/// 4. `class` - [optional] The class of the record to be updated
+/// 2. `payer` - The account that will pay for the record account
+/// 3. `record` - The record account to be updated
+/// 4. `system_program` - Required for account resizing operations
+/// 5. `class` - [optional] The class of the record to be updated
 /// # Security
 /// 1. The authority must be:
 ///    a. The record's owner, or
 ///    b. if the class is permissioned, the authority can be the permissioned authority
 pub struct UpdateRecordAccounts<'info> {
-    authority: &'info AccountInfo,
+    payer: &'info AccountInfo,
     record: &'info AccountInfo,
 }
 
@@ -31,7 +32,7 @@ impl<'info> TryFrom<&'info [AccountInfo]> for UpdateRecordAccounts<'info> {
     type Error = ProgramError;
 
     fn try_from(accounts: &'info [AccountInfo]) -> Result<Self, Self::Error> {
-        let [authority, record, _system_program, rest @ ..] = accounts else {
+        let [authority, payer, record, _system_program, rest @ ..] = accounts else {
             return Err(ProgramError::NotEnoughAccountKeys);
         };
 
@@ -42,7 +43,10 @@ impl<'info> TryFrom<&'info [AccountInfo]> for UpdateRecordAccounts<'info> {
         // Check if authority is the record owner or has a delegate
         Record::check_owner_or_delegate(record, rest.first(), authority)?;
 
-        Ok(Self { authority, record })
+        Ok(Self {
+            payer,
+            record,
+        })
     }
 }
 
@@ -78,7 +82,11 @@ impl<'info> UpdateRecord<'info> {
     pub fn execute(&self) -> ProgramResult {
         // Update the record data [this is safe, check safety docs]
         unsafe {
-            Record::update_data_unchecked(self.accounts.record, self.accounts.authority, self.data)
+            Record::update_data_unchecked(
+                self.accounts.record,
+                self.accounts.payer,
+                self.data,
+            )
         }
     }
 }

--- a/program/src/state/class.rs
+++ b/program/src/state/class.rs
@@ -157,7 +157,7 @@ impl<'info> Class<'info> {
     /// This function does not perform owner checks
     pub unsafe fn update_metadata_unchecked(
         class: &'info AccountInfo,
-        authority: &'info AccountInfo,
+        payer: &'info AccountInfo,
         metadata: &'info str,
     ) -> Result<(), ProgramError> {
         let name_len = {
@@ -170,14 +170,11 @@ impl<'info> Class<'info> {
         let new_len = offset + metadata.len();
 
         if new_len != current_len {
-            resize_account(class, authority, new_len, new_len < current_len)?;
+            resize_account(class, payer, new_len, new_len < current_len)?;
         }
 
         {
             let mut data_ref = class.try_borrow_mut_data()?;
-            unsafe {
-                Self::check_authority_unchecked(&data_ref, authority)?;
-            }
 
             let metadata_buffer = unsafe {
                 core::slice::from_raw_parts_mut(data_ref.as_mut_ptr().add(offset), metadata.len())

--- a/program/src/state/record.rs
+++ b/program/src/state/record.rs
@@ -299,7 +299,7 @@ impl<'info> Record<'info> {
     /// This function does not perform owner checks
     pub unsafe fn update_data_unchecked(
         record: &'info AccountInfo,
-        authority: &'info AccountInfo,
+        payer: &'info AccountInfo,
         data: &'info str,
     ) -> Result<(), ProgramError> {
         let name_len = {
@@ -312,14 +312,12 @@ impl<'info> Record<'info> {
         let new_len = offset + data.len();
 
         if new_len != current_len {
-            resize_account(record, authority, new_len, new_len < current_len)?;
+            resize_account(record, payer, new_len, new_len < current_len)?;
         }
 
         {
             let mut data_ref = record.try_borrow_mut_data()?;
-            if data_ref[DISCRIMINATOR_OFFSET].ne(&Self::DISCRIMINATOR) {
-                return Err(ProgramError::InvalidAccountData);
-            }
+
             let data_buffer = unsafe {
                 core::slice::from_raw_parts_mut(data_ref.as_mut_ptr().add(offset), data.len())
             };
@@ -337,7 +335,7 @@ impl<'info> Record<'info> {
         record: &'info AccountInfo,
         authority: &'info AccountInfo,
     ) -> Result<(), ProgramError> {
-        resize_account(record, authority, 1, true)?;
+        resize_account(record, authority, 0, true)?;
         {
             let mut data_ref = record.try_borrow_mut_data()?;
             data_ref[DISCRIMINATOR_OFFSET] = 0xff;

--- a/program/src/tests.rs
+++ b/program/src/tests.rs
@@ -701,6 +701,8 @@ fn create_class() {
 fn update_class_metadata() {
     // Authority
     let (authority, authority_data) = keyed_account_for_authority();
+    // Payer
+    let (payer, payer_data) = keyed_account_for_random_authority();
     // Class
     let (class, class_data) = keyed_account_for_class_default();
 
@@ -711,6 +713,7 @@ fn update_class_metadata() {
 
     let instruction = UpdateClassMetadata {
         authority,
+        payer,
         class,
         system_program,
     }
@@ -727,6 +730,7 @@ fn update_class_metadata() {
         &instruction,
         &[
             (authority, authority_data),
+            (payer, payer_data),
             (class, class_data),
             (system_program, system_program_data),
         ],
@@ -751,6 +755,7 @@ fn update_class_metadata_incorrect_authority() {
 
     let instruction = UpdateClassMetadata {
         authority: random_authority,
+        payer: random_authority,
         class,
         system_program,
     }
@@ -1033,6 +1038,8 @@ fn create_permissioned_record() {
 fn update_record() {
     // Owner
     let (owner, owner_data) = keyed_account_for_owner();
+    // Payer
+    let (payer, payer_data) = keyed_account_for_random_authority();
     // Class
     let (class, _class_data) = keyed_account_for_class_default();
     // Record
@@ -1047,6 +1054,7 @@ fn update_record() {
 
     let instruction = UpdateRecord {
         authority: owner,
+        payer,
         record,
         system_program,
         class: None,
@@ -1064,6 +1072,7 @@ fn update_record() {
         &instruction,
         &[
             (owner, owner_data),
+            (payer, payer_data),
             (record, record_data),
             (system_program, system_program_data),
         ],
@@ -1100,9 +1109,9 @@ fn update_record_with_metadata() {
     }
     .instruction(UpdateRecordTokenizableInstructionArgs {
         metadata: Metadata {
-            name: make_u32prefix_string("test"),
+            name: make_u32prefix_string("test2"),
             symbol: make_u32prefix_string("SRS"),
-            uri: make_u32prefix_string("test"),
+            uri: make_u32prefix_string("test2"),
             additional_metadata: vec![],
         },
     });
@@ -1132,6 +1141,8 @@ fn update_record_with_metadata() {
 fn update_record_with_delegate() {
     // Authority
     let (authority, authority_data) = keyed_account_for_authority();
+    // Payer
+    let (payer, payer_data) = keyed_account_for_random_authority();
     // Class
     let (class, class_data) = keyed_account_for_class(authority, true, false, "test", "test");
     // Record
@@ -1146,6 +1157,7 @@ fn update_record_with_delegate() {
 
     let instruction = UpdateRecord {
         authority,
+        payer,
         record,
         system_program,
         class: Some(class),
@@ -1163,6 +1175,7 @@ fn update_record_with_delegate() {
         &instruction,
         &[
             (authority, authority_data),
+            (payer, payer_data),
             (record, record_data),
             (system_program, system_program_data),
             (class, class_data),
@@ -1181,6 +1194,8 @@ fn update_record_with_delegate() {
 fn update_record_with_delegate_not_permissioned() {
     // Authority
     let (authority, authority_data) = keyed_account_for_authority();
+    // Payer
+    let (payer, payer_data) = keyed_account_for_random_authority();
     // Class
     let (class, class_data) = keyed_account_for_class(authority, false, false, "test", "test");
     // Record
@@ -1192,6 +1207,7 @@ fn update_record_with_delegate_not_permissioned() {
 
     let instruction = UpdateRecord {
         authority,
+        payer,
         record,
         system_program,
         class: Some(class),
@@ -1209,6 +1225,7 @@ fn update_record_with_delegate_not_permissioned() {
         &instruction,
         &[
             (authority, authority_data),
+            (payer, payer_data),
             (record, record_data),
             (system_program, system_program_data),
             (class, class_data),
@@ -1222,6 +1239,8 @@ fn update_record_with_delegate_not_permissioned() {
 fn update_record_with_delegate_incorrect_authority() {
     // Authority
     let (random_authority, random_authority_data) = keyed_account_for_random_authority();
+    // Payer
+    let (payer, payer_data) = keyed_account_for_random_authority();
     // Class
     let (class, class_data) = keyed_account_for_class(AUTHORITY, true, false, "test", "test");
     // Record
@@ -1233,6 +1252,7 @@ fn update_record_with_delegate_incorrect_authority() {
 
     let instruction = UpdateRecord {
         authority: random_authority,
+        payer,
         record,
         system_program,
         class: Some(class),
@@ -1250,6 +1270,7 @@ fn update_record_with_delegate_incorrect_authority() {
         &instruction,
         &[
             (random_authority, random_authority_data),
+            (payer, payer_data),
             (record, record_data),
             (system_program, system_program_data),
             (class, class_data),
@@ -1375,6 +1396,8 @@ fn fail_transfer_record_frozen() {
 fn delete_record() {
     // Owner
     let (owner, owner_data) = keyed_account_for_owner();
+    // Payer
+    let (payer, payer_data) = keyed_account_for_random_authority();
     // Class
     let (class, _class_data) = keyed_account_for_class_default();
     // Record
@@ -1383,6 +1406,7 @@ fn delete_record() {
 
     let instruction = DeleteRecord {
         authority: owner,
+        payer,
         record,
         class: None,
     }
@@ -1395,7 +1419,11 @@ fn delete_record() {
 
     mollusk.process_and_validate_instruction(
         &instruction,
-        &[(owner, owner_data), (record, record_data)],
+        &[
+            (owner, owner_data),
+            (payer, payer_data),
+            (record, record_data),
+        ],
         &[
             Check::success(),
             Check::account(&record).data(&[0xff]).build(),
@@ -1407,6 +1435,8 @@ fn delete_record() {
 fn delete_record_with_delegate() {
     // Authority
     let (authority, authority_data) = keyed_account_for_authority();
+    // Payer
+    let (payer, payer_data) = keyed_account_for_random_authority();
     // Class
     let (class, class_data) = keyed_account_for_class(authority, true, false, "test", "test");
     // Record
@@ -1415,6 +1445,7 @@ fn delete_record_with_delegate() {
 
     let instruction = DeleteRecord {
         authority,
+        payer,
         record,
         class: Some(class),
     }
@@ -1429,6 +1460,7 @@ fn delete_record_with_delegate() {
         &instruction,
         &[
             (authority, authority_data),
+            (payer, payer_data),
             (record, record_data),
             (class, class_data),
         ],
@@ -2066,6 +2098,8 @@ fn transfer_tokenized_record_delegate() {
 fn burn_tokenized_record() {
     // Owner
     let (owner, owner_data) = keyed_account_for_owner();
+    // Payer
+    let (payer, payer_data) = keyed_account_for_random_authority();
     // Class
     let (class, _class_data) = keyed_account_for_class_default();
     // Mint
@@ -2078,14 +2112,12 @@ fn burn_tokenized_record() {
     let (record, record_data) = keyed_account_for_record(class, 1, mint, false, 0, "test", b"test");
     // ATA
     let (token_account, token_account_data) = keyed_account_for_token(owner, mint, false);
-    // New ATA
-    let (new_token_account, new_token_account_data) =
-        keyed_account_for_token(RANDOM_PUBKEY, mint, false);
 
     let (token2022, token2022_data) = mollusk_svm_programs_token::token2022::keyed_account();
 
     let instruction = BurnTokenizedRecord {
         authority: owner,
+        payer,
         record,
         mint,
         token_account,
@@ -2106,10 +2138,10 @@ fn burn_tokenized_record() {
         &instruction,
         &[
             (owner, owner_data),
+            (payer, payer_data),
             (record, record_data),
             (mint, mint_data),
             (token_account, token_account_data),
-            (new_token_account, new_token_account_data),
             (token2022, token2022_data),
         ],
         &[Check::success()],
@@ -2120,6 +2152,8 @@ fn burn_tokenized_record() {
 fn burn_tokenized_record_delegate() {
     // Authority
     let (authority, authority_data) = keyed_account_for_authority();
+    // Payer
+    let (payer, payer_data) = keyed_account_for_random_authority();
     // Class
     let (class, class_data) = keyed_account_for_class(authority, true, false, "test", "test");
     // Mint
@@ -2132,14 +2166,12 @@ fn burn_tokenized_record_delegate() {
     let (record, record_data) = keyed_account_for_record(class, 1, mint, false, 0, "test", b"test");
     // ATA
     let (token_account, token_account_data) = keyed_account_for_token(OWNER, mint, false);
-    // New ATA
-    let (new_token_account, new_token_account_data) =
-        keyed_account_for_token(RANDOM_PUBKEY, mint, false);
 
     let (token2022, token2022_data) = mollusk_svm_programs_token::token2022::keyed_account();
 
     let instruction = BurnTokenizedRecord {
         authority,
+        payer,
         record,
         mint,
         token_account,
@@ -2160,10 +2192,10 @@ fn burn_tokenized_record_delegate() {
         &instruction,
         &[
             (authority, authority_data),
+            (payer, payer_data),
             (record, record_data),
             (mint, mint_data),
             (token_account, token_account_data),
-            (new_token_account, new_token_account_data),
             (token2022, token2022_data),
             (class, class_data),
         ],
@@ -2208,6 +2240,7 @@ fn mint_and_burn_tokenized_record() {
 
     let burn_instruction = BurnTokenizedRecord {
         authority: owner,
+        payer: owner,
         record,
         mint,
         token_account,
@@ -2247,6 +2280,8 @@ fn mint_and_burn_tokenized_record() {
 fn mint_and_burn_tokenized_record_delegate() {
     // Authority
     let (authority, authority_data) = keyed_account_for_authority();
+    // Payer
+    let (payer, payer_data) = keyed_account_for_random_authority();
     // Owner
     let (owner, owner_data) = keyed_account_for_owner();
     // Class
@@ -2281,8 +2316,9 @@ fn mint_and_burn_tokenized_record_delegate() {
     }
     .instruction();
 
-    let burn_instruction = BurnTokenizedRecord {
+    let burn_instruction = BurnTokenizedRecord {    
         authority,
+        payer: authority,
         record,
         mint,
         token_account,
@@ -2306,6 +2342,7 @@ fn mint_and_burn_tokenized_record_delegate() {
         ],
         &[
             (owner, owner_data),
+            (payer, payer_data),
             (authority, authority_data),
             (record, record_data),
             (mint, Account::default()),

--- a/program/src/utils.rs
+++ b/program/src/utils.rs
@@ -25,7 +25,7 @@ pub struct Context<'info> {
 /// * `zero_out` - Whether to zero out the new space (true if shrinking, false if expanding)
 pub fn resize_account(
     target_account: &AccountInfo,
-    authority: &AccountInfo,
+    payer: &AccountInfo,
     new_size: usize,
     zero_out: bool,
 ) -> ProgramResult {
@@ -44,7 +44,7 @@ pub fn resize_account(
             // Need more lamports for rent exemption
             let lamports_diff = new_minimum_balance.saturating_sub(target_account.lamports());
             Transfer {
-                from: authority,
+                from: payer,
                 to: target_account,
                 lamports: lamports_diff,
             }
@@ -55,8 +55,8 @@ pub fn resize_account(
             let lamports_diff = target_account
                 .lamports()
                 .saturating_sub(new_minimum_balance);
-            *authority.try_borrow_mut_lamports()? =
-                authority.lamports().saturating_add(lamports_diff);
+            *payer.try_borrow_mut_lamports()? =
+                payer.lamports().saturating_add(lamports_diff);
             *target_account.try_borrow_mut_lamports()? =
                 target_account.lamports().saturating_sub(lamports_diff);
         }

--- a/sdk/rust/src/client/instructions/create_record_tokenizable.rs
+++ b/sdk/rust/src/client/instructions/create_record_tokenizable.rs
@@ -8,8 +8,7 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use kaigan::types::U8PrefixString;
-
-use crate::types::Metadata;
+use crate::types::{Metadata, MetadataAdditionalMetadata};
 
 /// Accounts.
 #[derive(Debug)]
@@ -109,21 +108,7 @@ pub struct CreateRecordTokenizableInstructionArgs {
     pub metadata: Metadata,
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct CreateRecordTokenizableInstructionDataMetadataAdditionalMetadata {
-    pub label: String,
-    pub value: String,
-}
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct CreateRecordTokenizableInstructionDataMetadata {
-    pub name: String,
-    pub symbol: String,
-    pub uri: String,
-    pub additional_metadata:
-        Option<Vec<CreateRecordTokenizableInstructionDataMetadataAdditionalMetadata>>,
-}
+
 
 /// Instruction builder for `CreateRecordTokenizable`.
 ///

--- a/sdk/rust/src/client/instructions/create_record_tokenizable.rs
+++ b/sdk/rust/src/client/instructions/create_record_tokenizable.rs
@@ -8,7 +8,7 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use kaigan::types::U8PrefixString;
-use crate::types::{Metadata, MetadataAdditionalMetadata};
+use crate::types::Metadata;
 
 /// Accounts.
 #[derive(Debug)]
@@ -107,8 +107,6 @@ pub struct CreateRecordTokenizableInstructionArgs {
     pub name: U8PrefixString,
     pub metadata: Metadata,
 }
-
-
 
 /// Instruction builder for `CreateRecordTokenizable`.
 ///

--- a/sdk/rust/src/client/instructions/update_class_metadata.rs
+++ b/sdk/rust/src/client/instructions/update_class_metadata.rs
@@ -14,6 +14,8 @@ use kaigan::types::RemainderStr;
 pub struct UpdateClassMetadata {
     /// Authority used to update a class
     pub authority: solana_program::pubkey::Pubkey,
+    /// Account that will pay of get refunded for the class update
+    pub payer: solana_program::pubkey::Pubkey,
     /// Class account to be updated
     pub class: solana_program::pubkey::Pubkey,
     /// System Program used to extend our class account
@@ -34,10 +36,13 @@ impl UpdateClassMetadata {
         args: UpdateClassMetadataInstructionArgs,
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
-        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.authority,
             true,
+        ));
+        accounts.push(solana_program::instruction::AccountMeta::new(
+            self.payer, true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.class, false,
@@ -88,11 +93,13 @@ pub struct UpdateClassMetadataInstructionArgs {
 /// ### Accounts:
 ///
 ///   0. `[writable, signer]` authority
-///   1. `[writable]` class
-///   2. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   1. `[writable, signer]` payer
+///   2. `[writable]` class
+///   3. `[optional]` system_program (default to `11111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct UpdateClassMetadataBuilder {
     authority: Option<solana_program::pubkey::Pubkey>,
+    payer: Option<solana_program::pubkey::Pubkey>,
     class: Option<solana_program::pubkey::Pubkey>,
     system_program: Option<solana_program::pubkey::Pubkey>,
     metadata: Option<RemainderStr>,
@@ -107,6 +114,12 @@ impl UpdateClassMetadataBuilder {
     #[inline(always)]
     pub fn authority(&mut self, authority: solana_program::pubkey::Pubkey) -> &mut Self {
         self.authority = Some(authority);
+        self
+    }
+    /// Account that will pay of get refunded for the class update
+    #[inline(always)]
+    pub fn payer(&mut self, payer: solana_program::pubkey::Pubkey) -> &mut Self {
+        self.payer = Some(payer);
         self
     }
     /// Class account to be updated
@@ -149,6 +162,7 @@ impl UpdateClassMetadataBuilder {
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
         let accounts = UpdateClassMetadata {
             authority: self.authority.expect("authority is not set"),
+            payer: self.payer.expect("payer is not set"),
             class: self.class.expect("class is not set"),
             system_program: self
                 .system_program
@@ -166,6 +180,8 @@ impl UpdateClassMetadataBuilder {
 pub struct UpdateClassMetadataCpiAccounts<'a, 'b> {
     /// Authority used to update a class
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
+    /// Account that will pay of get refunded for the class update
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Class account to be updated
     pub class: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program used to extend our class account
@@ -178,6 +194,8 @@ pub struct UpdateClassMetadataCpi<'a, 'b> {
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Authority used to update a class
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
+    /// Account that will pay of get refunded for the class update
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Class account to be updated
     pub class: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program used to extend our class account
@@ -195,6 +213,7 @@ impl<'a, 'b> UpdateClassMetadataCpi<'a, 'b> {
         Self {
             __program: program,
             authority: accounts.authority,
+            payer: accounts.payer,
             class: accounts.class,
             system_program: accounts.system_program,
             __args: args,
@@ -234,9 +253,13 @@ impl<'a, 'b> UpdateClassMetadataCpi<'a, 'b> {
             bool,
         )],
     ) -> solana_program::entrypoint::ProgramResult {
-        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.authority.key,
+            true,
+        ));
+        accounts.push(solana_program::instruction::AccountMeta::new(
+            *self.payer.key,
             true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -263,9 +286,10 @@ impl<'a, 'b> UpdateClassMetadataCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(5 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.authority.clone());
+        account_infos.push(self.payer.clone());
         account_infos.push(self.class.clone());
         account_infos.push(self.system_program.clone());
         remaining_accounts
@@ -285,8 +309,9 @@ impl<'a, 'b> UpdateClassMetadataCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable, signer]` authority
-///   1. `[writable]` class
-///   2. `[]` system_program
+///   1. `[writable, signer]` payer
+///   2. `[writable]` class
+///   3. `[]` system_program
 #[derive(Clone, Debug)]
 pub struct UpdateClassMetadataCpiBuilder<'a, 'b> {
     instruction: Box<UpdateClassMetadataCpiBuilderInstruction<'a, 'b>>,
@@ -297,6 +322,7 @@ impl<'a, 'b> UpdateClassMetadataCpiBuilder<'a, 'b> {
         let instruction = Box::new(UpdateClassMetadataCpiBuilderInstruction {
             __program: program,
             authority: None,
+            payer: None,
             class: None,
             system_program: None,
             metadata: None,
@@ -311,6 +337,12 @@ impl<'a, 'b> UpdateClassMetadataCpiBuilder<'a, 'b> {
         authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
+        self
+    }
+    /// Account that will pay of get refunded for the class update
+    #[inline(always)]
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+        self.instruction.payer = Some(payer);
         self
     }
     /// Class account to be updated
@@ -386,6 +418,8 @@ impl<'a, 'b> UpdateClassMetadataCpiBuilder<'a, 'b> {
 
             authority: self.instruction.authority.expect("authority is not set"),
 
+            payer: self.instruction.payer.expect("payer is not set"),
+
             class: self.instruction.class.expect("class is not set"),
 
             system_program: self
@@ -405,6 +439,7 @@ impl<'a, 'b> UpdateClassMetadataCpiBuilder<'a, 'b> {
 struct UpdateClassMetadataCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     class: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     metadata: Option<RemainderStr>,

--- a/sdk/rust/src/client/instructions/update_record.rs
+++ b/sdk/rust/src/client/instructions/update_record.rs
@@ -14,6 +14,8 @@ use kaigan::types::RemainderVec;
 pub struct UpdateRecord {
     /// Record owner or class authority for permissioned classes
     pub authority: solana_program::pubkey::Pubkey,
+    /// Account that will pay of get refunded for the record update
+    pub payer: solana_program::pubkey::Pubkey,
     /// Record account to be updated
     pub record: solana_program::pubkey::Pubkey,
     /// System Program used to extend our record account
@@ -36,10 +38,13 @@ impl UpdateRecord {
         args: UpdateRecordInstructionArgs,
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
-        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.authority,
             true,
+        ));
+        accounts.push(solana_program::instruction::AccountMeta::new(
+            self.payer, true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.record,
@@ -101,12 +106,14 @@ pub struct UpdateRecordInstructionArgs {
 /// ### Accounts:
 ///
 ///   0. `[writable, signer]` authority
-///   1. `[writable]` record
-///   2. `[optional]` system_program (default to `11111111111111111111111111111111`)
-///   3. `[optional]` class
+///   1. `[writable, signer]` payer
+///   2. `[writable]` record
+///   3. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   4. `[optional]` class
 #[derive(Clone, Debug, Default)]
 pub struct UpdateRecordBuilder {
     authority: Option<solana_program::pubkey::Pubkey>,
+    payer: Option<solana_program::pubkey::Pubkey>,
     record: Option<solana_program::pubkey::Pubkey>,
     system_program: Option<solana_program::pubkey::Pubkey>,
     class: Option<solana_program::pubkey::Pubkey>,
@@ -122,6 +129,12 @@ impl UpdateRecordBuilder {
     #[inline(always)]
     pub fn authority(&mut self, authority: solana_program::pubkey::Pubkey) -> &mut Self {
         self.authority = Some(authority);
+        self
+    }
+    /// Account that will pay of get refunded for the record update
+    #[inline(always)]
+    pub fn payer(&mut self, payer: solana_program::pubkey::Pubkey) -> &mut Self {
+        self.payer = Some(payer);
         self
     }
     /// Record account to be updated
@@ -171,6 +184,7 @@ impl UpdateRecordBuilder {
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
         let accounts = UpdateRecord {
             authority: self.authority.expect("authority is not set"),
+            payer: self.payer.expect("payer is not set"),
             record: self.record.expect("record is not set"),
             system_program: self
                 .system_program
@@ -189,6 +203,8 @@ impl UpdateRecordBuilder {
 pub struct UpdateRecordCpiAccounts<'a, 'b> {
     /// Record owner or class authority for permissioned classes
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
+    /// Account that will pay of get refunded for the record update
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Record account to be updated
     pub record: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program used to extend our record account
@@ -203,6 +219,8 @@ pub struct UpdateRecordCpi<'a, 'b> {
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Record owner or class authority for permissioned classes
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
+    /// Account that will pay of get refunded for the record update
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Record account to be updated
     pub record: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program used to extend our record account
@@ -222,6 +240,7 @@ impl<'a, 'b> UpdateRecordCpi<'a, 'b> {
         Self {
             __program: program,
             authority: accounts.authority,
+            payer: accounts.payer,
             record: accounts.record,
             system_program: accounts.system_program,
             class: accounts.class,
@@ -262,9 +281,13 @@ impl<'a, 'b> UpdateRecordCpi<'a, 'b> {
             bool,
         )],
     ) -> solana_program::entrypoint::ProgramResult {
-        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.authority.key,
+            true,
+        ));
+        accounts.push(solana_program::instruction::AccountMeta::new(
+            *self.payer.key,
             true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -301,9 +324,10 @@ impl<'a, 'b> UpdateRecordCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(6 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.authority.clone());
+        account_infos.push(self.payer.clone());
         account_infos.push(self.record.clone());
         account_infos.push(self.system_program.clone());
         if let Some(class) = self.class {
@@ -326,9 +350,10 @@ impl<'a, 'b> UpdateRecordCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable, signer]` authority
-///   1. `[writable]` record
-///   2. `[]` system_program
-///   3. `[optional]` class
+///   1. `[writable, signer]` payer
+///   2. `[writable]` record
+///   3. `[]` system_program
+///   4. `[optional]` class
 #[derive(Clone, Debug)]
 pub struct UpdateRecordCpiBuilder<'a, 'b> {
     instruction: Box<UpdateRecordCpiBuilderInstruction<'a, 'b>>,
@@ -339,6 +364,7 @@ impl<'a, 'b> UpdateRecordCpiBuilder<'a, 'b> {
         let instruction = Box::new(UpdateRecordCpiBuilderInstruction {
             __program: program,
             authority: None,
+            payer: None,
             record: None,
             system_program: None,
             class: None,
@@ -354,6 +380,12 @@ impl<'a, 'b> UpdateRecordCpiBuilder<'a, 'b> {
         authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
+        self
+    }
+    /// Account that will pay of get refunded for the record update
+    #[inline(always)]
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+        self.instruction.payer = Some(payer);
         self
     }
     /// Record account to be updated
@@ -438,6 +470,8 @@ impl<'a, 'b> UpdateRecordCpiBuilder<'a, 'b> {
 
             authority: self.instruction.authority.expect("authority is not set"),
 
+            payer: self.instruction.payer.expect("payer is not set"),
+
             record: self.instruction.record.expect("record is not set"),
 
             system_program: self
@@ -459,6 +493,7 @@ impl<'a, 'b> UpdateRecordCpiBuilder<'a, 'b> {
 struct UpdateRecordCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     class: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/sdk/rust/src/client/instructions/update_record_tokenizable.rs
+++ b/sdk/rust/src/client/instructions/update_record_tokenizable.rs
@@ -7,13 +7,15 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use crate::types::{Metadata, MetadataAdditionalMetadata};
+use crate::types::Metadata;
 
 /// Accounts.
 #[derive(Debug)]
 pub struct UpdateRecordTokenizable {
     /// Record owner or class authority for permissioned classes
     pub authority: solana_program::pubkey::Pubkey,
+    /// Account that will pay of get refunded for the record update
+    pub payer: solana_program::pubkey::Pubkey,
     /// Record account to be updated
     pub record: solana_program::pubkey::Pubkey,
     /// System Program used to extend our record account
@@ -36,10 +38,13 @@ impl UpdateRecordTokenizable {
         args: UpdateRecordTokenizableInstructionArgs,
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
-        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.authority,
             true,
+        ));
+        accounts.push(solana_program::instruction::AccountMeta::new(
+            self.payer, true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.record,
@@ -96,19 +101,19 @@ pub struct UpdateRecordTokenizableInstructionArgs {
     pub metadata: Metadata,
 }
 
-
-
 /// Instruction builder for `UpdateRecordTokenizable`.
 ///
 /// ### Accounts:
 ///
 ///   0. `[writable, signer]` authority
-///   1. `[writable]` record
-///   2. `[optional]` system_program (default to `11111111111111111111111111111111`)
-///   3. `[optional]` class
+///   1. `[writable, signer]` payer
+///   2. `[writable]` record
+///   3. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   4. `[optional]` class
 #[derive(Clone, Debug, Default)]
 pub struct UpdateRecordTokenizableBuilder {
     authority: Option<solana_program::pubkey::Pubkey>,
+    payer: Option<solana_program::pubkey::Pubkey>,
     record: Option<solana_program::pubkey::Pubkey>,
     system_program: Option<solana_program::pubkey::Pubkey>,
     class: Option<solana_program::pubkey::Pubkey>,
@@ -124,6 +129,12 @@ impl UpdateRecordTokenizableBuilder {
     #[inline(always)]
     pub fn authority(&mut self, authority: solana_program::pubkey::Pubkey) -> &mut Self {
         self.authority = Some(authority);
+        self
+    }
+    /// Account that will pay of get refunded for the record update
+    #[inline(always)]
+    pub fn payer(&mut self, payer: solana_program::pubkey::Pubkey) -> &mut Self {
+        self.payer = Some(payer);
         self
     }
     /// Record account to be updated
@@ -173,6 +184,7 @@ impl UpdateRecordTokenizableBuilder {
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
         let accounts = UpdateRecordTokenizable {
             authority: self.authority.expect("authority is not set"),
+            payer: self.payer.expect("payer is not set"),
             record: self.record.expect("record is not set"),
             system_program: self
                 .system_program
@@ -191,6 +203,8 @@ impl UpdateRecordTokenizableBuilder {
 pub struct UpdateRecordTokenizableCpiAccounts<'a, 'b> {
     /// Record owner or class authority for permissioned classes
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
+    /// Account that will pay of get refunded for the record update
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Record account to be updated
     pub record: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program used to extend our record account
@@ -205,6 +219,8 @@ pub struct UpdateRecordTokenizableCpi<'a, 'b> {
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Record owner or class authority for permissioned classes
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
+    /// Account that will pay of get refunded for the record update
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Record account to be updated
     pub record: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program used to extend our record account
@@ -224,6 +240,7 @@ impl<'a, 'b> UpdateRecordTokenizableCpi<'a, 'b> {
         Self {
             __program: program,
             authority: accounts.authority,
+            payer: accounts.payer,
             record: accounts.record,
             system_program: accounts.system_program,
             class: accounts.class,
@@ -264,9 +281,13 @@ impl<'a, 'b> UpdateRecordTokenizableCpi<'a, 'b> {
             bool,
         )],
     ) -> solana_program::entrypoint::ProgramResult {
-        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.authority.key,
+            true,
+        ));
+        accounts.push(solana_program::instruction::AccountMeta::new(
+            *self.payer.key,
             true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -303,9 +324,10 @@ impl<'a, 'b> UpdateRecordTokenizableCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(6 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.authority.clone());
+        account_infos.push(self.payer.clone());
         account_infos.push(self.record.clone());
         account_infos.push(self.system_program.clone());
         if let Some(class) = self.class {
@@ -328,9 +350,10 @@ impl<'a, 'b> UpdateRecordTokenizableCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable, signer]` authority
-///   1. `[writable]` record
-///   2. `[]` system_program
-///   3. `[optional]` class
+///   1. `[writable, signer]` payer
+///   2. `[writable]` record
+///   3. `[]` system_program
+///   4. `[optional]` class
 #[derive(Clone, Debug)]
 pub struct UpdateRecordTokenizableCpiBuilder<'a, 'b> {
     instruction: Box<UpdateRecordTokenizableCpiBuilderInstruction<'a, 'b>>,
@@ -341,6 +364,7 @@ impl<'a, 'b> UpdateRecordTokenizableCpiBuilder<'a, 'b> {
         let instruction = Box::new(UpdateRecordTokenizableCpiBuilderInstruction {
             __program: program,
             authority: None,
+            payer: None,
             record: None,
             system_program: None,
             class: None,
@@ -356,6 +380,12 @@ impl<'a, 'b> UpdateRecordTokenizableCpiBuilder<'a, 'b> {
         authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
+        self
+    }
+    /// Account that will pay of get refunded for the record update
+    #[inline(always)]
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+        self.instruction.payer = Some(payer);
         self
     }
     /// Record account to be updated
@@ -444,6 +474,8 @@ impl<'a, 'b> UpdateRecordTokenizableCpiBuilder<'a, 'b> {
 
             authority: self.instruction.authority.expect("authority is not set"),
 
+            payer: self.instruction.payer.expect("payer is not set"),
+
             record: self.instruction.record.expect("record is not set"),
 
             system_program: self
@@ -465,6 +497,7 @@ impl<'a, 'b> UpdateRecordTokenizableCpiBuilder<'a, 'b> {
 struct UpdateRecordTokenizableCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     class: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/sdk/rust/src/client/instructions/update_record_tokenizable.rs
+++ b/sdk/rust/src/client/instructions/update_record_tokenizable.rs
@@ -7,8 +7,7 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-
-use crate::types::Metadata;
+use crate::types::{Metadata, MetadataAdditionalMetadata};
 
 /// Accounts.
 #[derive(Debug)]
@@ -97,21 +96,7 @@ pub struct UpdateRecordTokenizableInstructionArgs {
     pub metadata: Metadata,
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct UpdateRecordTokenizableInstructionDataMetadataAdditionalMetadata {
-    pub label: String,
-    pub value: String,
-}
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct UpdateRecordTokenizableInstructionDataMetadata {
-    pub name: String,
-    pub symbol: String,
-    pub uri: String,
-    /// Additional metadata for Token22 Metadata Extension compatible Metadata format
-    pub additional_metadata: Vec<UpdateRecordTokenizableInstructionDataMetadataAdditionalMetadata>,
-}
+
 
 /// Instruction builder for `UpdateRecordTokenizable`.
 ///
@@ -194,7 +179,7 @@ impl UpdateRecordTokenizableBuilder {
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
             class: self.class,
         };
-        let args: UpdateRecordTokenizableInstructionArgs = UpdateRecordTokenizableInstructionArgs {
+        let args = UpdateRecordTokenizableInstructionArgs {
             metadata: self.metadata.clone().expect("metadata is not set"),
         };
 

--- a/sdk/ts/src/instructions/burnTokenizedRecord.ts
+++ b/sdk/ts/src/instructions/burnTokenizedRecord.ts
@@ -30,6 +30,8 @@ import {
 export type BurnTokenizedRecordInstructionAccounts = {
   /** Record owner or class authority for permissioned classes */
   authority: Signer;
+  /** Account that will get refunded for the tokenized record burn */
+  payer: Signer;
   /** Mint account for the tokenized record */
   mint: PublicKey | Pda;
   /** Token Account for the tokenized record */
@@ -84,24 +86,29 @@ export function burnTokenizedRecord(
       isWritable: true as boolean,
       value: input.authority ?? null,
     },
-    mint: { index: 1, isWritable: true as boolean, value: input.mint ?? null },
+    payer: {
+      index: 1,
+      isWritable: true as boolean,
+      value: input.payer ?? null,
+    },
+    mint: { index: 2, isWritable: true as boolean, value: input.mint ?? null },
     tokenAccount: {
-      index: 2,
+      index: 3,
       isWritable: true as boolean,
       value: input.tokenAccount ?? null,
     },
     record: {
-      index: 3,
+      index: 4,
       isWritable: true as boolean,
       value: input.record ?? null,
     },
     token2022: {
-      index: 4,
+      index: 5,
       isWritable: false as boolean,
       value: input.token2022 ?? null,
     },
     class: {
-      index: 5,
+      index: 6,
       isWritable: false as boolean,
       value: input.class ?? null,
     },

--- a/sdk/ts/src/instructions/createRecordTokenizable.ts
+++ b/sdk/ts/src/instructions/createRecordTokenizable.ts
@@ -28,6 +28,7 @@ import {
   ResolvedAccountsWithIndices,
   getAccountMetasAndSigners,
 } from '../shared';
+import { Metadata, getMetadataSerializer } from '../types';
 
 // Accounts.
 export type CreateRecordTokenizableInstructionAccounts = {
@@ -51,26 +52,14 @@ export type CreateRecordTokenizableInstructionData = {
   expiration: bigint;
   name: string;
   /** Token22 Metadata Extension compatible Metadata format */
-  metadata: {
-    name: string;
-    symbol: string;
-    uri: string;
-    /** Additional metadata for Token22 Metadata Extension compatible Metadata format */
-    additionalMetadata: Array<{ label: string; value: string }>;
-  };
+  metadata: Metadata;
 };
 
 export type CreateRecordTokenizableInstructionDataArgs = {
   expiration: number | bigint;
   name: string;
   /** Token22 Metadata Extension compatible Metadata format */
-  metadata: {
-    name: string;
-    symbol?: string;
-    uri: string;
-    /** Additional metadata for Token22 Metadata Extension compatible Metadata format */
-    additionalMetadata: Array<{ label: string; value: string }>;
-  };
+  metadata: Metadata;
 };
 
 export function getCreateRecordTokenizableInstructionDataSerializer(): Serializer<
@@ -87,26 +76,7 @@ export function getCreateRecordTokenizableInstructionDataSerializer(): Serialize
         ['discriminator', u8()],
         ['expiration', i64()],
         ['name', string({ size: u8() })],
-        [
-          'metadata',
-          mapSerializer<any, any, any>(
-            struct<any>([
-              ['name', string()],
-              ['symbol', string()],
-              ['uri', string()],
-              [
-                'additionalMetadata',
-                array(
-                  struct<any>([
-                    ['label', string()],
-                    ['value', string()],
-                  ])
-                ),
-              ],
-            ]),
-            (value) => ({ ...value, symbol: value.symbol ?? 'SRS' })
-          ),
-        ],
+        ['metadata', getMetadataSerializer()],
       ],
       { description: 'CreateRecordTokenizableInstructionData' }
     ),

--- a/sdk/ts/src/instructions/deleteRecord.ts
+++ b/sdk/ts/src/instructions/deleteRecord.ts
@@ -30,6 +30,8 @@ import {
 export type DeleteRecordInstructionAccounts = {
   /** Record owner or class authority for permissioned classes */
   authority: Signer;
+  /** Account that will get refunded for the record deletion */
+  payer: Signer;
   /** Record account to be updated */
   record: PublicKey | Pda;
   /** Class account of the record */
@@ -75,13 +77,18 @@ export function deleteRecord(
       isWritable: true as boolean,
       value: input.authority ?? null,
     },
-    record: {
+    payer: {
       index: 1,
+      isWritable: true as boolean,
+      value: input.payer ?? null,
+    },
+    record: {
+      index: 2,
       isWritable: true as boolean,
       value: input.record ?? null,
     },
     class: {
-      index: 2,
+      index: 3,
       isWritable: false as boolean,
       value: input.class ?? null,
     },

--- a/sdk/ts/src/instructions/updateClassMetadata.ts
+++ b/sdk/ts/src/instructions/updateClassMetadata.ts
@@ -31,6 +31,8 @@ import {
 export type UpdateClassMetadataInstructionAccounts = {
   /** Authority used to update a class */
   authority: Signer;
+  /** Account that will pay of get refunded for the class update */
+  payer: Signer;
   /** Class account to be updated */
   class: PublicKey | Pda;
   /** System Program used to extend our class account */
@@ -91,13 +93,18 @@ export function updateClassMetadata(
       isWritable: true as boolean,
       value: input.authority ?? null,
     },
-    class: {
+    payer: {
       index: 1,
+      isWritable: true as boolean,
+      value: input.payer ?? null,
+    },
+    class: {
+      index: 2,
       isWritable: true as boolean,
       value: input.class ?? null,
     },
     systemProgram: {
-      index: 2,
+      index: 3,
       isWritable: false as boolean,
       value: input.systemProgram ?? null,
     },

--- a/sdk/ts/src/instructions/updateRecord.ts
+++ b/sdk/ts/src/instructions/updateRecord.ts
@@ -31,6 +31,8 @@ import {
 export type UpdateRecordInstructionAccounts = {
   /** Record owner or class authority for permissioned classes */
   authority: Signer;
+  /** Account that will pay of get refunded for the record update */
+  payer: Signer;
   /** Record account to be updated */
   record: PublicKey | Pda;
   /** System Program used to extend our record account */
@@ -88,18 +90,23 @@ export function updateRecord(
       isWritable: true as boolean,
       value: input.authority ?? null,
     },
-    record: {
+    payer: {
       index: 1,
+      isWritable: true as boolean,
+      value: input.payer ?? null,
+    },
+    record: {
+      index: 2,
       isWritable: true as boolean,
       value: input.record ?? null,
     },
     systemProgram: {
-      index: 2,
+      index: 3,
       isWritable: false as boolean,
       value: input.systemProgram ?? null,
     },
     class: {
-      index: 3,
+      index: 4,
       isWritable: false as boolean,
       value: input.class ?? null,
     },

--- a/sdk/ts/src/instructions/updateRecordTokenizable.ts
+++ b/sdk/ts/src/instructions/updateRecordTokenizable.ts
@@ -27,11 +27,14 @@ import {
   ResolvedAccountsWithIndices,
   getAccountMetasAndSigners,
 } from '../shared';
+import { Metadata, getMetadataSerializer } from '../types';
 
 // Accounts.
 export type UpdateRecordTokenizableInstructionAccounts = {
   /** Record owner or class authority for permissioned classes */
   authority: Signer;
+  /** Account that will pay of get refunded for the record update */
+  payer: Signer;
   /** Record account to be updated */
   record: PublicKey | Pda;
   /** System Program used to extend our record account */
@@ -44,24 +47,12 @@ export type UpdateRecordTokenizableInstructionAccounts = {
 export type UpdateRecordTokenizableInstructionData = {
   discriminator: number;
   /** Token22 Metadata Extension compatible Metadata format */
-  metadata: {
-    name: string;
-    symbol: string;
-    uri: string;
-    /** Additional metadata for Token22 Metadata Extension compatible Metadata format */
-    additionalMetadata: Array<{ label: string; value: string }>;
-  };
+  metadata: Metadata;
 };
 
 export type UpdateRecordTokenizableInstructionDataArgs = {
   /** Token22 Metadata Extension compatible Metadata format */
-  metadata: {
-    name: string;
-    symbol?: string;
-    uri: string;
-    /** Additional metadata for Token22 Metadata Extension compatible Metadata format */
-    additionalMetadata: Array<{ label: string; value: string }>;
-  };
+  metadata: Metadata;
 };
 
 export function getUpdateRecordTokenizableInstructionDataSerializer(): Serializer<
@@ -76,26 +67,7 @@ export function getUpdateRecordTokenizableInstructionDataSerializer(): Serialize
     struct<UpdateRecordTokenizableInstructionData>(
       [
         ['discriminator', u8()],
-        [
-          'metadata',
-          mapSerializer<any, any, any>(
-            struct<any>([
-              ['name', string()],
-              ['symbol', string()],
-              ['uri', string()],
-              [
-                'additionalMetadata',
-                array(
-                  struct<any>([
-                    ['label', string()],
-                    ['value', string()],
-                  ])
-                ),
-              ],
-            ]),
-            (value) => ({ ...value, symbol: value.symbol ?? 'SRS' })
-          ),
-        ],
+        ['metadata', getMetadataSerializer()],
       ],
       { description: 'UpdateRecordTokenizableInstructionData' }
     ),
@@ -129,18 +101,23 @@ export function updateRecordTokenizable(
       isWritable: true as boolean,
       value: input.authority ?? null,
     },
-    record: {
+    payer: {
       index: 1,
+      isWritable: true as boolean,
+      value: input.payer ?? null,
+    },
+    record: {
+      index: 2,
       isWritable: true as boolean,
       value: input.record ?? null,
     },
     systemProgram: {
-      index: 2,
+      index: 3,
       isWritable: false as boolean,
       value: input.systemProgram ?? null,
     },
     class: {
-      index: 3,
+      index: 4,
       isWritable: false as boolean,
       value: input.class ?? null,
     },


### PR DESCRIPTION
Added `payer` account in addition to the `authority` account in:
- UpdateClass
- UpdateRecord
- DeleteRecord
- BurnTokenizedRecord

Changed the SDK to have the new account struct and generated the new types

DeleteRecord didn't give back the rent before, added the refund by hard coding the Rent for one byte like this: 
```rust
// Refund the payer of all the lamports
self.accounts.payer.borrow_mut_lamports_unchecked()
    .checked_add(*self.accounts.record.borrow_lamports_unchecked())
    .and_then(|x| x.checked_sub(ONE_LAMPORT_RENT))
    .ok_or(ProgramError::InvalidAccountData)?;

*self.accounts.record.borrow_mut_lamports_unchecked() = ONE_LAMPORT_RENT;
```

**Note**: This is the most efficient way to set the rent to 1 byte, but if the rent value changes it could create some problems: 
- Rent increase: bricks the program but it's an easy update
- Rent decrease: it goes unnotices and we leave a some lamports in the account