### PR TITLE
feat(ts-sdk): add deterministic D3/Doma SRS forward+reverse resolution with tests

### DIFF
--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -22,10 +22,13 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
+    "@noble/hashes": "^1.8.0",
     "@metaplex-foundation/umi": "^1.2.0",
+    "@solana/web3.js": "^1.98.4",
     "@solana/kit": "^2.1.0",
     "bn.js": "^5.2.1",
     "borsh": "^2.0.0",
-    "borsher": "^4.0.0"
+    "borsher": "^4.0.0",
+    "tr46": "^5.1.0"
   }
 }

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -10,5 +10,6 @@ export * from './accounts';
 export * from './errors';
 export * from './instructions';
 export * from './programs';
+export * from './resolution';
 export * from './shared';
 export * from './types';

--- a/sdk/ts/src/resolution/caip.ts
+++ b/sdk/ts/src/resolution/caip.ts
@@ -1,0 +1,101 @@
+import { ResolutionInputError } from './errors';
+
+const CAIP2_PATTERN = /^[a-z0-9]{3,8}:[a-zA-Z0-9-]{1,32}$/;
+
+export interface ParsedWalletValue {
+  chainId: string;
+  walletAddress: string;
+}
+
+export function normalizeChainCaip2(chainId: string): string {
+  const trimmed = chainId.trim();
+  if (!CAIP2_PATTERN.test(trimmed)) {
+    throw new ResolutionInputError(`Invalid CAIP-2 chain id: ${chainId}`);
+  }
+
+  return trimmed.toLowerCase();
+}
+
+function parseCaipWalletValue(value: string): ParsedWalletValue | null {
+  const trimmed = value.trim();
+  const parts = trimmed.split(':');
+
+  if (parts.length < 3) {
+    return null;
+  }
+
+  // did:pkh:<namespace>:<reference>:<account>
+  if (parts[0] === 'did' && parts[1] === 'pkh' && parts.length >= 5) {
+    const chain = `${parts[2]}:${parts[3]}`;
+    if (!CAIP2_PATTERN.test(chain)) {
+      return null;
+    }
+
+    const walletAddress = parts.slice(4).join(':').trim();
+    if (walletAddress.length === 0) {
+      return null;
+    }
+
+    return { chainId: chain.toLowerCase(), walletAddress };
+  }
+
+  const chainId = `${parts[0]}:${parts[1]}`;
+  if (!CAIP2_PATTERN.test(chainId)) {
+    return null;
+  }
+
+  const walletAddress = parts.slice(2).join(':').trim();
+  if (walletAddress.length === 0) {
+    return null;
+  }
+
+  return { chainId: chainId.toLowerCase(), walletAddress };
+}
+
+export function parseWalletTuple(
+  key: string,
+  value: string,
+  defaultChainCaip2: string
+): ParsedWalletValue | null {
+  const normalizedDefault = normalizeChainCaip2(defaultChainCaip2);
+  const normalizedKey = key.trim().toUpperCase();
+
+  if (normalizedKey === 'WALLET') {
+    const parsed = parseCaipWalletValue(value);
+    if (parsed) {
+      return parsed;
+    }
+
+    const walletAddress = value.trim();
+    if (walletAddress.length === 0) {
+      return null;
+    }
+
+    return { chainId: normalizedDefault, walletAddress };
+  }
+
+  if (!normalizedKey.startsWith('WALLET:')) {
+    return null;
+  }
+
+  const chainInKeyRaw = key.slice('WALLET:'.length).trim();
+  if (chainInKeyRaw.length === 0) {
+    return null;
+  }
+
+  const chainId = normalizeChainCaip2(chainInKeyRaw);
+  const parsed = parseCaipWalletValue(value);
+  if (parsed) {
+    return {
+      chainId,
+      walletAddress: parsed.walletAddress,
+    };
+  }
+
+  const walletAddress = value.trim();
+  if (walletAddress.length === 0) {
+    return null;
+  }
+
+  return { chainId, walletAddress };
+}

--- a/sdk/ts/src/resolution/constants.ts
+++ b/sdk/ts/src/resolution/constants.ts
@@ -1,0 +1,10 @@
+import { PublicKey } from '@solana/web3.js';
+
+export const SRS_DEFAULT_PROGRAM_ID = new PublicKey(
+  'srsUi2TVUUCyGcZdopxJauk8ZBzgAaHHZCVUhm5ifPa'
+);
+
+export const SRS_RECORD_PDA_SEED = Buffer.from('record', 'utf8');
+export const SRS_RECORD_DISCRIMINATOR = 2;
+export const SRS_RECORD_TUPLE_VERSION = 1;
+export const DEFAULT_SOLANA_CAIP2 = 'solana:mainnet';

--- a/sdk/ts/src/resolution/errors.ts
+++ b/sdk/ts/src/resolution/errors.ts
@@ -1,0 +1,20 @@
+export class ResolutionCodecError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ResolutionCodecError';
+  }
+}
+
+export class ResolutionInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ResolutionInputError';
+  }
+}
+
+export class SrsRecordDecodeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SrsRecordDecodeError';
+  }
+}

--- a/sdk/ts/src/resolution/forwardResolver.ts
+++ b/sdk/ts/src/resolution/forwardResolver.ts
@@ -1,0 +1,73 @@
+import { PublicKey } from '@solana/web3.js';
+import { parseWalletTuple, normalizeChainCaip2 } from './caip';
+import { DEFAULT_SOLANA_CAIP2, SRS_DEFAULT_PROGRAM_ID } from './constants';
+import { namehash } from './namehash';
+import { findRecordPda } from './pda';
+import type { RawRecordAccountProvider } from './provider';
+import { decodeSrsRecord } from './recordDecoder';
+import { parseResolutionTuples } from './tupleCodec';
+
+export interface DomaForwardResolverConfig {
+  provider: RawRecordAccountProvider;
+  domaClassAddress: PublicKey;
+  programId?: PublicKey;
+  defaultChainCaip2?: string;
+}
+
+export class DomaForwardResolver {
+  private readonly provider: RawRecordAccountProvider;
+  private readonly domaClassAddress: PublicKey;
+  private readonly programId: PublicKey;
+  private readonly defaultChainCaip2: string;
+
+  constructor(config: DomaForwardResolverConfig) {
+    this.provider = config.provider;
+    this.domaClassAddress = config.domaClassAddress;
+    this.programId = config.programId ?? SRS_DEFAULT_PROGRAM_ID;
+    this.defaultChainCaip2 = normalizeChainCaip2(
+      config.defaultChainCaip2 ?? DEFAULT_SOLANA_CAIP2
+    );
+  }
+
+  async resolve(
+    name: string,
+    chainCaip2: string = this.defaultChainCaip2
+  ): Promise<string | null> {
+    const normalizedChain = normalizeChainCaip2(chainCaip2);
+    const tokenId = namehash(name);
+    const [recordPda] = findRecordPda(
+      this.domaClassAddress,
+      tokenId,
+      this.programId
+    );
+
+    const tuples = await this.fetchRecordTuples(recordPda);
+    if (!tuples) {
+      return null;
+    }
+
+    let selectedWallet: string | null = null;
+    for (const [key, value] of tuples) {
+      const parsed = parseWalletTuple(key, value, normalizedChain);
+      if (!parsed) {
+        continue;
+      }
+
+      if (parsed.chainId === normalizedChain) {
+        selectedWallet = parsed.walletAddress;
+      }
+    }
+
+    return selectedWallet;
+  }
+
+  private async fetchRecordTuples(recordPda: PublicKey) {
+    const raw = await this.provider.fetchRawRecordAccount(recordPda);
+    if (!raw) {
+      return null;
+    }
+
+    const decoded = decodeSrsRecord(raw);
+    return parseResolutionTuples(decoded.data);
+  }
+}

--- a/sdk/ts/src/resolution/index.ts
+++ b/sdk/ts/src/resolution/index.ts
@@ -1,0 +1,39 @@
+export {
+  DomaForwardResolver,
+  type DomaForwardResolverConfig,
+} from './forwardResolver';
+export {
+  SrsReverseResolver,
+  type ForwardNameResolver,
+  type SrsReverseResolverConfig,
+} from './reverseResolver';
+export { DomaSrsResolver, type DomaSrsResolverConfig } from './resolver';
+export {
+  RpcRawRecordAccountProvider,
+  type RawRecordAccountProvider,
+} from './provider';
+
+export {
+  serializeResolutionTuples,
+  parseResolutionTuples,
+  type ResolutionTuple,
+} from './tupleCodec';
+
+export { decodeSrsRecord, type DecodedSrsRecord } from './recordDecoder';
+export { namehash, normalizeName } from './namehash';
+export { findRecordPda, reverseRecordSeed } from './pda';
+export {
+  parseWalletTuple,
+  normalizeChainCaip2,
+  type ParsedWalletValue,
+} from './caip';
+export {
+  ResolutionCodecError,
+  ResolutionInputError,
+  SrsRecordDecodeError,
+} from './errors';
+export {
+  DEFAULT_SOLANA_CAIP2,
+  SRS_DEFAULT_PROGRAM_ID,
+  SRS_RECORD_PDA_SEED,
+} from './constants';

--- a/sdk/ts/src/resolution/namehash.ts
+++ b/sdk/ts/src/resolution/namehash.ts
@@ -1,0 +1,53 @@
+import { keccak_256 } from '@noble/hashes/sha3';
+import { ResolutionInputError } from './errors';
+
+const textEncoder = new TextEncoder();
+const tr46: {
+  toASCII: (name: string, options?: Record<string, unknown>) => string | null;
+} = require('tr46');
+
+function concat32(left: Uint8Array, right: Uint8Array): Uint8Array {
+  const out = new Uint8Array(64);
+  out.set(left, 0);
+  out.set(right, 32);
+  return out;
+}
+
+export function normalizeName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    throw new ResolutionInputError('Name cannot be empty');
+  }
+
+  const normalized = tr46.toASCII(trimmed, {
+    checkBidi: true,
+    checkHyphens: true,
+    useSTD3ASCIIRules: true,
+    verifyDNSLength: true,
+    transitionalProcessing: false,
+  });
+
+  if (!normalized) {
+    throw new ResolutionInputError(`Could not normalize name: ${name}`);
+  }
+
+  return normalized.toLowerCase();
+}
+
+export function namehash(name: string): Uint8Array {
+  const normalized = normalizeName(name);
+  if (normalized === '.') {
+    return new Uint8Array(32);
+  }
+
+  const labels = normalized.split('.').filter((label) => label.length > 0);
+  let node = new Uint8Array(32);
+
+  for (let i = labels.length - 1; i >= 0; i -= 1) {
+    const labelBytes = textEncoder.encode(labels[i]);
+    const labelHash = Uint8Array.from(keccak_256(labelBytes));
+    node = Uint8Array.from(keccak_256(concat32(node, labelHash)));
+  }
+
+  return node;
+}

--- a/sdk/ts/src/resolution/pda.ts
+++ b/sdk/ts/src/resolution/pda.ts
@@ -1,0 +1,25 @@
+import { PublicKey } from '@solana/web3.js';
+import { SRS_DEFAULT_PROGRAM_ID, SRS_RECORD_PDA_SEED } from './constants';
+import { ResolutionInputError } from './errors';
+
+export function findRecordPda(
+  classAddress: PublicKey,
+  tokenId: Uint8Array,
+  programId: PublicKey = SRS_DEFAULT_PROGRAM_ID
+): [PublicKey, number] {
+  if (tokenId.length === 0 || tokenId.length > 32) {
+    throw new ResolutionInputError(
+      `tokenId must be in range [1, 32], got ${tokenId.length}`
+    );
+  }
+
+  return PublicKey.findProgramAddressSync(
+    [SRS_RECORD_PDA_SEED, classAddress.toBuffer(), Buffer.from(tokenId)],
+    programId
+  );
+}
+
+export function reverseRecordSeed(wallet: string): Uint8Array {
+  const walletPk = new PublicKey(wallet);
+  return walletPk.toBytes();
+}

--- a/sdk/ts/src/resolution/provider.ts
+++ b/sdk/ts/src/resolution/provider.ts
@@ -1,0 +1,27 @@
+import { Connection, PublicKey } from '@solana/web3.js';
+
+export interface RawRecordAccountProvider {
+  fetchRawRecordAccount(recordPda: PublicKey): Promise<Uint8Array | null>;
+}
+
+export class RpcRawRecordAccountProvider implements RawRecordAccountProvider {
+  private readonly connection: Connection;
+  private readonly commitment:
+    | 'processed'
+    | 'confirmed'
+    | 'finalized'
+    | undefined;
+
+  constructor(
+    connection: Connection,
+    commitment?: 'processed' | 'confirmed' | 'finalized'
+  ) {
+    this.connection = connection;
+    this.commitment = commitment;
+  }
+
+  async fetchRawRecordAccount(recordPda: PublicKey): Promise<Uint8Array | null> {
+    const account = await this.connection.getAccountInfo(recordPda, this.commitment);
+    return account?.data ?? null;
+  }
+}

--- a/sdk/ts/src/resolution/recordDecoder.ts
+++ b/sdk/ts/src/resolution/recordDecoder.ts
@@ -1,0 +1,104 @@
+import { PublicKey } from '@solana/web3.js';
+import { SRS_RECORD_DISCRIMINATOR } from './constants';
+import { SrsRecordDecodeError } from './errors';
+
+const PUBKEY_BYTES = 32;
+
+export interface DecodedSrsRecord {
+  discriminator: number;
+  class: PublicKey;
+  ownerType: number;
+  owner: PublicKey;
+  isFrozen: boolean;
+  expiry: bigint;
+  seed: Uint8Array;
+  data: Uint8Array;
+}
+
+function readPublicKey(raw: Uint8Array, offset: number): PublicKey {
+  const end = offset + PUBKEY_BYTES;
+  if (end > raw.length) {
+    throw new SrsRecordDecodeError('Unexpected EOF while reading public key');
+  }
+
+  return new PublicKey(raw.subarray(offset, end));
+}
+
+function readBigInt64LE(raw: Uint8Array, offset: number): bigint {
+  if (offset + 8 > raw.length) {
+    throw new SrsRecordDecodeError('Unexpected EOF while reading i64');
+  }
+
+  const view = new DataView(raw.buffer, raw.byteOffset, raw.byteLength);
+  return view.getBigInt64(offset, true);
+}
+
+export function decodeSrsRecord(rawAccountData: Uint8Array): DecodedSrsRecord {
+  const minimumHeaderLength = 1 + 32 + 1 + 32 + 1 + 8 + 1;
+  if (rawAccountData.length < minimumHeaderLength) {
+    throw new SrsRecordDecodeError('SRS record is too short');
+  }
+
+  let offset = 0;
+  const discriminator = rawAccountData[offset];
+  if (discriminator === undefined) {
+    throw new SrsRecordDecodeError('Missing discriminator');
+  }
+  offset += 1;
+
+  if (discriminator !== SRS_RECORD_DISCRIMINATOR) {
+    throw new SrsRecordDecodeError(
+      `Unexpected record discriminator: ${discriminator}`
+    );
+  }
+
+  const classPk = readPublicKey(rawAccountData, offset);
+  offset += PUBKEY_BYTES;
+
+  const ownerType = rawAccountData[offset];
+  if (ownerType === undefined) {
+    throw new SrsRecordDecodeError('Missing owner type');
+  }
+  offset += 1;
+
+  const ownerPk = readPublicKey(rawAccountData, offset);
+  offset += PUBKEY_BYTES;
+
+  const frozen = rawAccountData[offset];
+  if (frozen === undefined) {
+    throw new SrsRecordDecodeError('Missing frozen flag');
+  }
+  offset += 1;
+
+  if (frozen !== 0 && frozen !== 1) {
+    throw new SrsRecordDecodeError('Invalid boolean frozen value');
+  }
+
+  const expiry = readBigInt64LE(rawAccountData, offset);
+  offset += 8;
+
+  const seedLength = rawAccountData[offset];
+  if (seedLength === undefined) {
+    throw new SrsRecordDecodeError('Missing seed length');
+  }
+  offset += 1;
+
+  const seedEnd = offset + seedLength;
+  if (seedEnd > rawAccountData.length) {
+    throw new SrsRecordDecodeError('Unexpected EOF while reading seed');
+  }
+
+  const seed = rawAccountData.subarray(offset, seedEnd);
+  const data = rawAccountData.subarray(seedEnd);
+
+  return {
+    discriminator,
+    class: classPk,
+    ownerType,
+    owner: ownerPk,
+    isFrozen: frozen === 1,
+    expiry,
+    seed,
+    data,
+  };
+}

--- a/sdk/ts/src/resolution/resolver.ts
+++ b/sdk/ts/src/resolution/resolver.ts
@@ -1,0 +1,65 @@
+import { PublicKey } from '@solana/web3.js';
+import { ResolutionInputError } from './errors';
+import {
+  DomaForwardResolver,
+  type DomaForwardResolverConfig,
+} from './forwardResolver';
+import {
+  SrsReverseResolver,
+  type SrsReverseResolverConfig,
+} from './reverseResolver';
+
+export interface DomaSrsResolverConfig {
+  provider: DomaForwardResolverConfig['provider'];
+  domaClassAddress?: PublicKey;
+  // Backward-compatible alias for older call sites.
+  forwardClassAddress?: PublicKey;
+  reverseClassAddress: PublicKey;
+  programId?: PublicKey;
+  defaultChainCaip2?: string;
+  verifyReverseWithForward?: boolean;
+}
+
+export class DomaSrsResolver {
+  private readonly forwardResolver: DomaForwardResolver;
+  private readonly reverseResolver: SrsReverseResolver;
+
+  constructor(config: DomaSrsResolverConfig) {
+    const domaClassAddress = config.domaClassAddress ?? config.forwardClassAddress;
+    if (!domaClassAddress) {
+      throw new ResolutionInputError('domaClassAddress is required');
+    }
+
+    this.forwardResolver = new DomaForwardResolver({
+      provider: config.provider,
+      domaClassAddress,
+      programId: config.programId,
+      defaultChainCaip2: config.defaultChainCaip2,
+    });
+
+    const reverseConfig: SrsReverseResolverConfig = {
+      provider: config.provider,
+      reverseClassAddress: config.reverseClassAddress,
+      programId: config.programId,
+      defaultChainCaip2: config.defaultChainCaip2,
+      verifyReverseWithForward: config.verifyReverseWithForward,
+      forwardVerifier: this.forwardResolver,
+    };
+
+    this.reverseResolver = new SrsReverseResolver(reverseConfig);
+  }
+
+  async resolve(name: string, chainCaip2?: string): Promise<string | null> {
+    return this.forwardResolver.resolve(name, chainCaip2);
+  }
+
+  async reverseResolve(wallet: string): Promise<string | null> {
+    return this.reverseResolver.reverseResolve(wallet);
+  }
+
+  async batchReverseResolve(
+    wallets: readonly string[]
+  ): Promise<Array<string | null>> {
+    return this.reverseResolver.batchReverseResolve(wallets);
+  }
+}

--- a/sdk/ts/src/resolution/reverseResolver.ts
+++ b/sdk/ts/src/resolution/reverseResolver.ts
@@ -1,0 +1,108 @@
+import { PublicKey } from '@solana/web3.js';
+import { normalizeChainCaip2 } from './caip';
+import { DEFAULT_SOLANA_CAIP2, SRS_DEFAULT_PROGRAM_ID } from './constants';
+import { ResolutionInputError } from './errors';
+import { normalizeName } from './namehash';
+import { findRecordPda, reverseRecordSeed } from './pda';
+import type { RawRecordAccountProvider } from './provider';
+import { decodeSrsRecord } from './recordDecoder';
+import { parseResolutionTuples } from './tupleCodec';
+
+export interface ForwardNameResolver {
+  resolve(name: string, chainCaip2?: string): Promise<string | null>;
+}
+
+export interface SrsReverseResolverConfig {
+  provider: RawRecordAccountProvider;
+  reverseClassAddress: PublicKey;
+  programId?: PublicKey;
+  defaultChainCaip2?: string;
+  verifyReverseWithForward?: boolean;
+  forwardVerifier?: ForwardNameResolver;
+}
+
+export class SrsReverseResolver {
+  private readonly provider: RawRecordAccountProvider;
+  private readonly reverseClassAddress: PublicKey;
+  private readonly programId: PublicKey;
+  private readonly defaultChainCaip2: string;
+  private readonly verifyReverseWithForward: boolean;
+  private readonly forwardVerifier?: ForwardNameResolver;
+
+  constructor(config: SrsReverseResolverConfig) {
+    this.provider = config.provider;
+    this.reverseClassAddress = config.reverseClassAddress;
+    this.programId = config.programId ?? SRS_DEFAULT_PROGRAM_ID;
+    this.defaultChainCaip2 = normalizeChainCaip2(
+      config.defaultChainCaip2 ?? DEFAULT_SOLANA_CAIP2
+    );
+    this.verifyReverseWithForward = config.verifyReverseWithForward ?? true;
+    this.forwardVerifier = config.forwardVerifier;
+
+    if (this.verifyReverseWithForward && !this.forwardVerifier) {
+      throw new ResolutionInputError(
+        'forwardVerifier is required when verifyReverseWithForward is enabled'
+      );
+    }
+  }
+
+  async reverseResolve(wallet: string): Promise<string | null> {
+    const reverseSeed = reverseRecordSeed(wallet);
+    const [recordPda] = findRecordPda(
+      this.reverseClassAddress,
+      reverseSeed,
+      this.programId
+    );
+
+    const tuples = await this.fetchRecordTuples(recordPda);
+    if (!tuples) {
+      return null;
+    }
+
+    let selectedName: string | null = null;
+    for (const [key, value] of tuples) {
+      if (key.trim().toUpperCase() !== 'NAME') {
+        continue;
+      }
+
+      const candidateName = value.trim();
+      if (candidateName.length > 0) {
+        selectedName = normalizeName(candidateName);
+      }
+    }
+
+    if (!selectedName) {
+      return null;
+    }
+
+    if (!this.verifyReverseWithForward) {
+      return selectedName;
+    }
+
+    const resolvedWallet = await this.forwardVerifier?.resolve(
+      selectedName,
+      this.defaultChainCaip2
+    );
+    if (!resolvedWallet) {
+      return null;
+    }
+
+    return resolvedWallet === wallet ? selectedName : null;
+  }
+
+  async batchReverseResolve(
+    wallets: readonly string[]
+  ): Promise<Array<string | null>> {
+    return Promise.all(wallets.map((wallet) => this.reverseResolve(wallet)));
+  }
+
+  private async fetchRecordTuples(recordPda: PublicKey) {
+    const raw = await this.provider.fetchRawRecordAccount(recordPda);
+    if (!raw) {
+      return null;
+    }
+
+    const decoded = decodeSrsRecord(raw);
+    return parseResolutionTuples(decoded.data);
+  }
+}

--- a/sdk/ts/src/resolution/tr46.d.ts
+++ b/sdk/ts/src/resolution/tr46.d.ts
@@ -1,0 +1,16 @@
+declare module 'tr46' {
+  export interface ToAsciiOptions {
+    checkBidi?: boolean;
+    checkHyphens?: boolean;
+    checkJoiners?: boolean;
+    processingOption?: 'nontransitional' | 'transitional';
+    transitionalProcessing?: boolean;
+    useSTD3ASCIIRules?: boolean;
+    verifyDNSLength?: boolean;
+  }
+
+  export function toASCII(
+    domainName: string,
+    options?: ToAsciiOptions
+  ): string | null;
+}

--- a/sdk/ts/src/resolution/tupleCodec.ts
+++ b/sdk/ts/src/resolution/tupleCodec.ts
@@ -1,0 +1,114 @@
+import { SRS_RECORD_TUPLE_VERSION } from './constants';
+import { ResolutionCodecError } from './errors';
+
+export type ResolutionTuple = readonly [key: string, value: string];
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder('utf-8', { fatal: true });
+
+function ensureU16(value: number, label: string): void {
+  if (!Number.isInteger(value) || value < 0 || value > 0xffff) {
+    throw new ResolutionCodecError(`${label} must fit into u16`);
+  }
+}
+
+function writeU16(view: DataView, offset: number, value: number): number {
+  view.setUint16(offset, value, true);
+  return offset + 2;
+}
+
+function readU16(view: DataView, offset: number): number {
+  if (offset + 2 > view.byteLength) {
+    throw new ResolutionCodecError('Unexpected EOF while reading u16');
+  }
+  return view.getUint16(offset, true);
+}
+
+export function serializeResolutionTuples(
+  tuples: readonly ResolutionTuple[]
+): Uint8Array {
+  ensureU16(tuples.length, 'tuple count');
+
+  const encoded = tuples.map(([key, value]) => {
+    const keyBytes = textEncoder.encode(key);
+    const valueBytes = textEncoder.encode(value);
+    ensureU16(keyBytes.length, 'key length');
+    ensureU16(valueBytes.length, 'value length');
+    return { keyBytes, valueBytes };
+  });
+
+  let total = 1 + 2;
+  for (const tuple of encoded) {
+    total += 2 + tuple.keyBytes.length + 2 + tuple.valueBytes.length;
+  }
+
+  const buffer = new ArrayBuffer(total);
+  const view = new DataView(buffer);
+  const out = new Uint8Array(buffer);
+
+  let offset = 0;
+  out[offset++] = SRS_RECORD_TUPLE_VERSION;
+  offset = writeU16(view, offset, encoded.length);
+
+  for (const tuple of encoded) {
+    offset = writeU16(view, offset, tuple.keyBytes.length);
+    out.set(tuple.keyBytes, offset);
+    offset += tuple.keyBytes.length;
+
+    offset = writeU16(view, offset, tuple.valueBytes.length);
+    out.set(tuple.valueBytes, offset);
+    offset += tuple.valueBytes.length;
+  }
+
+  return out;
+}
+
+export function parseResolutionTuples(data: Uint8Array): ResolutionTuple[] {
+  if (data.length < 3) {
+    throw new ResolutionCodecError('Tuple payload too short');
+  }
+
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  let offset = 0;
+  const version = data[offset];
+  if (version === undefined) {
+    throw new ResolutionCodecError('Missing tuple payload version');
+  }
+  offset += 1;
+
+  if (version !== SRS_RECORD_TUPLE_VERSION) {
+    throw new ResolutionCodecError(`Unsupported tuple payload version: ${version}`);
+  }
+
+  const tupleCount = readU16(view, offset);
+  offset += 2;
+
+  const tuples: ResolutionTuple[] = [];
+  for (let i = 0; i < tupleCount; i += 1) {
+    const keyLen = readU16(view, offset);
+    offset += 2;
+
+    if (offset + keyLen > data.length) {
+      throw new ResolutionCodecError('Unexpected EOF while reading key');
+    }
+    const key = textDecoder.decode(data.subarray(offset, offset + keyLen));
+    offset += keyLen;
+
+    const valueLen = readU16(view, offset);
+    offset += 2;
+
+    if (offset + valueLen > data.length) {
+      throw new ResolutionCodecError('Unexpected EOF while reading value');
+    }
+    const value = textDecoder.decode(data.subarray(offset, offset + valueLen));
+    offset += valueLen;
+
+    tuples.push([key, value]);
+  }
+
+  if (offset !== data.length) {
+    throw new ResolutionCodecError('Trailing bytes after tuple payload');
+  }
+
+  return tuples;
+}

--- a/sdk/ts/test/helpers.ts
+++ b/sdk/ts/test/helpers.ts
@@ -1,0 +1,51 @@
+import { PublicKey } from '@solana/web3.js';
+
+export function deterministicPublicKey(seedByte: number): PublicKey {
+  const bytes = new Uint8Array(32);
+  bytes.fill(seedByte);
+  return new PublicKey(bytes);
+}
+
+export interface BuildSrsRecordOptions {
+  classAddress: PublicKey;
+  ownerAddress: PublicKey;
+  seed: Uint8Array;
+  data: Uint8Array;
+  ownerType?: number;
+  isFrozen?: boolean;
+  expiry?: bigint;
+}
+
+export function buildSrsRecordAccountData(
+  options: BuildSrsRecordOptions
+): Uint8Array {
+  if (options.seed.length > 0xff) {
+    throw new Error('seed must fit in u8');
+  }
+
+  const fixedLength = 1 + 32 + 1 + 32 + 1 + 8 + 1;
+  const out = new Uint8Array(fixedLength + options.seed.length + options.data.length);
+  const view = new DataView(out.buffer);
+
+  let offset = 0;
+  out[offset++] = 2;
+
+  out.set(options.classAddress.toBytes(), offset);
+  offset += 32;
+
+  out[offset++] = options.ownerType ?? 0;
+
+  out.set(options.ownerAddress.toBytes(), offset);
+  offset += 32;
+
+  out[offset++] = options.isFrozen ? 1 : 0;
+  view.setBigInt64(offset, options.expiry ?? 0n, true);
+  offset += 8;
+
+  out[offset++] = options.seed.length;
+  out.set(options.seed, offset);
+  offset += options.seed.length;
+
+  out.set(options.data, offset);
+  return out;
+}

--- a/sdk/ts/test/resolution.spec.ts
+++ b/sdk/ts/test/resolution.spec.ts
@@ -1,0 +1,387 @@
+import { expect } from 'chai';
+import { PublicKey } from '@solana/web3.js';
+import {
+  decodeSrsRecord,
+  DomaForwardResolver,
+  DomaSrsResolver,
+  findRecordPda,
+  namehash,
+  parseResolutionTuples,
+  reverseRecordSeed,
+  serializeResolutionTuples,
+  SrsReverseResolver,
+  type RawRecordAccountProvider,
+} from '../src/resolution';
+import { buildSrsRecordAccountData, deterministicPublicKey } from './helpers';
+
+class InMemoryRecordProvider implements RawRecordAccountProvider {
+  private readonly records = new Map<string, Uint8Array>();
+
+  put(recordPda: PublicKey, data: Uint8Array): void {
+    this.records.set(recordPda.toBase58(), data);
+  }
+
+  async fetchRawRecordAccount(recordPda: PublicKey): Promise<Uint8Array | null> {
+    return this.records.get(recordPda.toBase58()) ?? null;
+  }
+}
+
+describe('resolution codec', () => {
+  it('serializes and parses resolution tuples', () => {
+    const tuples = [
+      ['WALLET:solana:mainnet', deterministicPublicKey(88).toBase58()],
+      ['NAME', 'alice.sol'],
+    ] as const;
+
+    const encoded = serializeResolutionTuples(tuples);
+    const decoded = parseResolutionTuples(encoded);
+
+    expect(decoded).to.deep.equal(tuples);
+  });
+
+  it('emits UTF-8 payload compatible with current SRS string record data', () => {
+    const tuples = [
+      ['WALLET', deterministicPublicKey(89).toBase58()],
+      ['NAME', 'alice.sol'],
+    ] as const;
+
+    const encoded = serializeResolutionTuples(tuples);
+    const decodedUtf8 = new TextDecoder('utf-8', { fatal: true }).decode(encoded);
+
+    expect(decodedUtf8.length).to.be.greaterThan(0);
+    expect(parseResolutionTuples(encoded)).to.deep.equal(tuples);
+  });
+
+  it('decodes SRS account data and extracts tuple payload', () => {
+    const classAddress = deterministicPublicKey(20);
+    const ownerAddress = deterministicPublicKey(21);
+    const seed = namehash('alice.sol');
+    const tuples = serializeResolutionTuples([['NAME', 'alice.sol']]);
+
+    const rawRecord = buildSrsRecordAccountData({
+      classAddress,
+      ownerAddress,
+      seed,
+      data: tuples,
+      expiry: 123n,
+    });
+
+    const decoded = decodeSrsRecord(rawRecord);
+    expect(decoded.class.toBase58()).to.equal(classAddress.toBase58());
+    expect(decoded.owner.toBase58()).to.equal(ownerAddress.toBase58());
+    expect(decoded.expiry).to.equal(123n);
+    expect(parseResolutionTuples(decoded.data)).to.deep.equal([['NAME', 'alice.sol']]);
+  });
+});
+
+describe('DomaForwardResolver', () => {
+  it('resolves forward records with chain-aware last-write-wins', async () => {
+    const domaClassAddress = deterministicPublicKey(30);
+    const ownerAddress = deterministicPublicKey(32);
+    const latestWallet = deterministicPublicKey(33).toBase58();
+
+    const provider = new InMemoryRecordProvider();
+    const resolver = new DomaForwardResolver({
+      provider,
+      domaClassAddress,
+      defaultChainCaip2: 'solana:mainnet',
+    });
+
+    const seed = namehash('alice.sol');
+    const [recordPda] = findRecordPda(domaClassAddress, seed);
+
+    provider.put(
+      recordPda,
+      buildSrsRecordAccountData({
+        classAddress: domaClassAddress,
+        ownerAddress,
+        seed,
+        data: serializeResolutionTuples([
+          ['WALLET:solana:mainnet', deterministicPublicKey(34).toBase58()],
+          ['WALLET:eip155:1', '0x123'],
+          ['WALLET', latestWallet],
+        ]),
+      })
+    );
+
+    const resolved = await resolver.resolve('alice.sol');
+    expect(resolved).to.equal(latestWallet);
+  });
+
+  it('resolves token-owned forward records and supports DID-PKH wallet values', async () => {
+    const domaClassAddress = deterministicPublicKey(35);
+    const tokenOwnerAddress = deterministicPublicKey(37);
+    const wallet = deterministicPublicKey(38).toBase58();
+
+    const provider = new InMemoryRecordProvider();
+    const resolver = new DomaForwardResolver({
+      provider,
+      domaClassAddress,
+      defaultChainCaip2: 'solana:mainnet',
+    });
+
+    const seed = namehash('tokenized.sol');
+    const [recordPda] = findRecordPda(domaClassAddress, seed);
+
+    provider.put(
+      recordPda,
+      buildSrsRecordAccountData({
+        classAddress: domaClassAddress,
+        ownerAddress: tokenOwnerAddress,
+        ownerType: 1,
+        seed,
+        data: serializeResolutionTuples([
+          ['WALLET', `did:pkh:solana:mainnet:${wallet}`],
+        ]),
+      })
+    );
+
+    const resolved = await resolver.resolve('tokenized.sol');
+    expect(resolved).to.equal(wallet);
+  });
+
+  it('supports CAIP-10 wallet values', async () => {
+    const domaClassAddress = deterministicPublicKey(45);
+    const ownerAddress = deterministicPublicKey(46);
+    const wallet = deterministicPublicKey(47).toBase58();
+
+    const provider = new InMemoryRecordProvider();
+    const resolver = new DomaForwardResolver({
+      provider,
+      domaClassAddress,
+      defaultChainCaip2: 'solana:mainnet',
+    });
+
+    const seed = namehash('caip10.sol');
+    const [recordPda] = findRecordPda(domaClassAddress, seed);
+
+    provider.put(
+      recordPda,
+      buildSrsRecordAccountData({
+        classAddress: domaClassAddress,
+        ownerAddress,
+        seed,
+        data: serializeResolutionTuples([
+          ['WALLET', `solana:mainnet:${wallet}`],
+        ]),
+      })
+    );
+
+    const resolved = await resolver.resolve('caip10.sol');
+    expect(resolved).to.equal(wallet);
+  });
+});
+
+describe('SrsReverseResolver', () => {
+  it('requires forward verifier when verification is enabled by default', () => {
+    const provider = new InMemoryRecordProvider();
+
+    expect(
+      () =>
+        new SrsReverseResolver({
+          provider,
+          reverseClassAddress: deterministicPublicKey(90),
+        })
+    ).to.throw('forwardVerifier is required when verifyReverseWithForward is enabled');
+  });
+
+  it('reverse resolves name only when forward mapping matches', async () => {
+    const domaClassAddress = deterministicPublicKey(40);
+    const reverseClassAddress = deterministicPublicKey(41);
+    const ownerAddress = deterministicPublicKey(42);
+    const wallet = deterministicPublicKey(43).toBase58();
+    const name = 'alice.sol';
+
+    const provider = new InMemoryRecordProvider();
+    const forwardResolver = new DomaForwardResolver({
+      provider,
+      domaClassAddress,
+    });
+    const reverseResolver = new SrsReverseResolver({
+      provider,
+      reverseClassAddress,
+      forwardVerifier: forwardResolver,
+      verifyReverseWithForward: true,
+    });
+
+    const forwardSeed = namehash(name);
+    const [forwardPda] = findRecordPda(domaClassAddress, forwardSeed);
+    provider.put(
+      forwardPda,
+      buildSrsRecordAccountData({
+        classAddress: domaClassAddress,
+        ownerAddress,
+        seed: forwardSeed,
+        data: serializeResolutionTuples([['WALLET', wallet]]),
+      })
+    );
+
+    const reverseSeed = reverseRecordSeed(wallet);
+    const [reversePda] = findRecordPda(reverseClassAddress, reverseSeed);
+    provider.put(
+      reversePda,
+      buildSrsRecordAccountData({
+        classAddress: reverseClassAddress,
+        ownerAddress,
+        seed: reverseSeed,
+        data: serializeResolutionTuples([['NAME', 'ALICE.sol']]),
+      })
+    );
+
+    const reverse = await reverseResolver.reverseResolve(wallet);
+    expect(reverse).to.equal(name);
+  });
+
+  it('returns null for reverse mapping mismatch', async () => {
+    const domaClassAddress = deterministicPublicKey(50);
+    const reverseClassAddress = deterministicPublicKey(51);
+    const ownerAddress = deterministicPublicKey(52);
+    const wallet = deterministicPublicKey(53).toBase58();
+
+    const provider = new InMemoryRecordProvider();
+    const forwardResolver = new DomaForwardResolver({
+      provider,
+      domaClassAddress,
+    });
+    const reverseResolver = new SrsReverseResolver({
+      provider,
+      reverseClassAddress,
+      forwardVerifier: forwardResolver,
+      verifyReverseWithForward: true,
+    });
+
+    const forwardSeed = namehash('alice.sol');
+    const [forwardPda] = findRecordPda(domaClassAddress, forwardSeed);
+    provider.put(
+      forwardPda,
+      buildSrsRecordAccountData({
+        classAddress: domaClassAddress,
+        ownerAddress,
+        seed: forwardSeed,
+        data: serializeResolutionTuples([
+          ['WALLET', deterministicPublicKey(54).toBase58()],
+        ]),
+      })
+    );
+
+    const reverseSeed = reverseRecordSeed(wallet);
+    const [reversePda] = findRecordPda(reverseClassAddress, reverseSeed);
+    provider.put(
+      reversePda,
+      buildSrsRecordAccountData({
+        classAddress: reverseClassAddress,
+        ownerAddress,
+        seed: reverseSeed,
+        data: serializeResolutionTuples([['NAME', 'alice.sol']]),
+      })
+    );
+
+    const reverse = await reverseResolver.reverseResolve(wallet);
+    expect(reverse).to.equal(null);
+  });
+
+  it('batch reverse resolves wallets in order', async () => {
+    const reverseClassAddress = deterministicPublicKey(61);
+    const ownerAddress = deterministicPublicKey(62);
+
+    const walletA = deterministicPublicKey(63).toBase58();
+    const walletB = deterministicPublicKey(64).toBase58();
+
+    const provider = new InMemoryRecordProvider();
+    const reverseResolver = new SrsReverseResolver({
+      provider,
+      reverseClassAddress,
+      verifyReverseWithForward: false,
+    });
+
+    const reverseSeedA = reverseRecordSeed(walletA);
+    const reverseSeedB = reverseRecordSeed(walletB);
+    const [reversePdaA] = findRecordPda(reverseClassAddress, reverseSeedA);
+    const [reversePdaB] = findRecordPda(reverseClassAddress, reverseSeedB);
+
+    provider.put(
+      reversePdaA,
+      buildSrsRecordAccountData({
+        classAddress: reverseClassAddress,
+        ownerAddress,
+        seed: reverseSeedA,
+        data: serializeResolutionTuples([['NAME', 'alice.sol']]),
+      })
+    );
+
+    provider.put(
+      reversePdaB,
+      buildSrsRecordAccountData({
+        classAddress: reverseClassAddress,
+        ownerAddress,
+        seed: reverseSeedB,
+        data: serializeResolutionTuples([['NAME', 'bob.sol']]),
+      })
+    );
+
+    const results = await reverseResolver.batchReverseResolve([walletA, walletB]);
+    expect(results).to.deep.equal(['alice.sol', 'bob.sol']);
+  });
+
+  it('reverse resolves from standalone reverse class without forward dependency when verification disabled', async () => {
+    const reverseClassAddress = deterministicPublicKey(71);
+    const ownerAddress = deterministicPublicKey(72);
+    const wallet = deterministicPublicKey(73).toBase58();
+
+    const provider = new InMemoryRecordProvider();
+    const reverseResolver = new SrsReverseResolver({
+      provider,
+      reverseClassAddress,
+      verifyReverseWithForward: false,
+    });
+
+    const seed = reverseRecordSeed(wallet);
+    const [reversePda] = findRecordPda(reverseClassAddress, seed);
+
+    provider.put(
+      reversePda,
+      buildSrsRecordAccountData({
+        classAddress: reverseClassAddress,
+        ownerAddress,
+        seed,
+        data: serializeResolutionTuples([['NAME', 'standalone.sol']]),
+      })
+    );
+
+    const resolved = await reverseResolver.reverseResolve(wallet);
+    expect(resolved).to.equal('standalone.sol');
+  });
+});
+
+describe('DomaSrsResolver compatibility facade', () => {
+  it('supports legacy forwardClassAddress alias', async () => {
+    const forwardClassAddress = deterministicPublicKey(101);
+    const reverseClassAddress = deterministicPublicKey(102);
+    const ownerAddress = deterministicPublicKey(103);
+
+    const provider = new InMemoryRecordProvider();
+    const resolver = new DomaSrsResolver({
+      provider,
+      forwardClassAddress,
+      reverseClassAddress,
+    });
+
+    const seed = namehash('legacy.sol');
+    const [forwardPda] = findRecordPda(forwardClassAddress, seed);
+
+    provider.put(
+      forwardPda,
+      buildSrsRecordAccountData({
+        classAddress: forwardClassAddress,
+        ownerAddress,
+        seed,
+        data: serializeResolutionTuples([
+          ['WALLET', deterministicPublicKey(104).toBase58()],
+        ]),
+      })
+    );
+
+    const resolved = await resolver.resolve('legacy.sol');
+    expect(resolved).to.equal(deterministicPublicKey(104).toBase58());
+  });
+});


### PR DESCRIPTION
This PR adds a TypeScript SDK resolution module for SRS, **enabling name → 
  wallet (forward)** and **wallet → name (reverse)** lookups against on-chain Solana  
  Record Service accounts.

  Forward resolution is the primary flow; reverse resolution is a separate,
  verification-guarded feature.

  What's Included

  Core primitives

  - Tuple payload codec — `serializeResolutionTuples` / `parseResolutionTuples` for
  versioned key-value encoding in record.data
  - SRS record decoder — `decodeSrsRecord` parses raw account bytes into a typed
  `DecodedSrsRecord`
  - PDA helpers — deterministic account derivation:
    - Forward: ["record", <class_pubkey>, <namehash(name)>]
    - Reverse: ["record", <reverse_class_pubkey>, <wallet_pubkey_bytes>]
  - Name normalization — TR46 (IDNA2008) normalization + Keccak-256 namehash
  - CAIP-aware wallet parsing — supports plain addresses, CAIP-10, and DID-PKH
  (did:pkh:...) formats
  - Error types — `ResolutionCodecError`, `ResolutionInputError`,
  `SrsRecordDecodeError`

  Resolvers

  - `DomaForwardResolver` — resolves name → wallet for a given chain (CAIP-2).
  Supports WALLET and WALLET:<caip2> keys with last-write-wins for duplicate
  chain entries.
  - `SrsReverseResolver` — resolves wallet → name via NAME key. Forward
  verification is enabled by default (verifyReverseWithForward: true); can be
  disabled for standalone reverse-only use.
  - `DomaSrsResolver` — compatibility facade composing forward + reverse
  resolvers. Supports legacy forwardClassAddress alias.
  - `RpcRawRecordAccountProvider` — concrete provider for fetching raw record
  accounts via RPC.

  Module exports

  - New src/resolution/index.ts barrel, re-exported from SDK root src/index.ts.

  Dependencies added

  - @noble/hashes (^1.8.0) — `Keccak-256` for namehash
  - tr46 (^5.1.0) — IDNA2008 name normalization
  - @solana/web3.js (^1.98.4) — PublicKey and PDA utilities (added alongside
  existing @solana/kit v2, which doesn't yet expose these)

  Test Coverage

  12 tests across 4 suites in sdk/ts/test/resolution.spec.ts:
  - `Codec` (3) — tuple round-trip, UTF-8 payload compat, SRS record decode
  - `Forward` (3) — chain-aware last-write-wins, token-owned records, DID-PKH and
  CAIP-10 parsing
  - `Reverse` (5) — verification match/mismatch, batch resolve, standalone mode,
  constructor validation
  - `Facade` (1) — legacy forwardClassAddress alias

  All SDK TS tests pass.