### PR TITLE
feat: store UTF-8 record names in account state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid",
  "crypto-common 0.2.1",
  "ctutils",
 ]
@@ -2492,6 +2499,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3434,6 +3452,7 @@ dependencies = [
  "pinocchio",
  "pinocchio-associated-token-account",
  "pinocchio-system",
+ "sha2 0.11.0",
  "solana-account",
  "solana-feature-set",
  "solana-precompiles",

--- a/codama.ts
+++ b/codama.ts
@@ -43,7 +43,7 @@ const root = rootNode(
                     structFieldTypeNode({ name: 'owner', type: publicKeyTypeNode() }),
                     structFieldTypeNode({ name: 'isFrozen', type: booleanTypeNode() }),
                     structFieldTypeNode({ name: 'expiry', type: numberTypeNode("i64") }),
-                    structFieldTypeNode({ name: 'seed', type: sizePrefixTypeNode(bytesTypeNode(), numberTypeNode("u8")) }),
+                    structFieldTypeNode({ name: 'name', type: sizePrefixTypeNode(stringTypeNode("utf8"), numberTypeNode("u16")) }),
                     structFieldTypeNode({ name: 'data', type: bytesTypeNode() }),
                 ])
             }),
@@ -222,7 +222,10 @@ const root = rootNode(
                     instructionArgumentNode({ 
                         name: 'expiration', type: numberTypeNode("i64") 
                     }),
-                    instructionArgumentNode({ name: 'seed', type: sizePrefixTypeNode(bytesTypeNode(), numberTypeNode("u8"))}),
+                    instructionArgumentNode({
+                        name: 'name',
+                        type: sizePrefixTypeNode(stringTypeNode("utf8"), numberTypeNode("u16")),
+                    }),
                     instructionArgumentNode({ name: 'data', type: bytesTypeNode() }),
                 ],
                 accounts: [
@@ -248,7 +251,7 @@ const root = rootNode(
                         name: "record",
                         isSigner: false,
                         isWritable: true,
-                        docs: ["Record account to be created"]
+                        docs: ["Record PDA derived from [\"record\", class, SHA-256(\"srs-record-name-v1\" || UTF-8(name))]"]
                     }),
                     instructionAccountNode({
                         name: "systemProgram",
@@ -281,7 +284,10 @@ const root = rootNode(
                     instructionArgumentNode({ 
                         name: 'expiration', type: numberTypeNode("i64") 
                     }),
-                    instructionArgumentNode({ name: 'seed', type: sizePrefixTypeNode(bytesTypeNode(), numberTypeNode("u8")) }),
+                    instructionArgumentNode({
+                        name: 'name',
+                        type: sizePrefixTypeNode(stringTypeNode("utf8"), numberTypeNode("u16")),
+                    }),
                     instructionArgumentNode({ name: 'metadata', type: definedTypeLinkNode('metadata')})
                 ],
                 accounts: [
@@ -307,7 +313,7 @@ const root = rootNode(
                         name: "record",
                         isSigner: false,
                         isWritable: true,
-                        docs: ["Record account to be created"]
+                        docs: ["Record PDA derived from [\"record\", class, SHA-256(\"srs-record-name-v1\" || UTF-8(name))]"]
                     }),
                     instructionAccountNode({
                         name: "systemProgram",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -10,11 +10,13 @@ crate-type = ["lib", "cdylib"]
 [features]
 default = ["perf"]
 perf = []
+sha2 = ["dep:sha2"]
 
 [dependencies]
 pinocchio = "0.8.3"
 pinocchio-system = "0.2.3"
 pinocchio-associated-token-account = "0.1.1"
+sha2 = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
 solana-record-service-client = { workspace = true }
@@ -29,3 +31,8 @@ solana-program = "2.2.1"
 kaigan = ">=0.2.6"
 borsh = "^0.10"
 hex = "0.4.3"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", priority = 0, check-cfg = [
+    'cfg(target_os, values("solana"))',
+] }

--- a/program/src/instructions/create_record.rs
+++ b/program/src/instructions/create_record.rs
@@ -1,17 +1,21 @@
 #[cfg(not(feature = "perf"))]
-use crate::constants::MAX_SEED_LEN;
-#[cfg(not(feature = "perf"))]
 use pinocchio::log::sol_log;
 
 use core::mem::size_of;
 use pinocchio::{
-    account_info::AccountInfo, instruction::{Seed, Signer}, log::sol_log_64, program_error::ProgramError, pubkey::try_find_program_address, sysvars::{rent::Rent, Sysvar}, ProgramResult
+    account_info::AccountInfo,
+    instruction::{Seed, Signer},
+    log::sol_log_64,
+    program_error::ProgramError,
+    pubkey::try_find_program_address,
+    sysvars::{rent::Rent, Sysvar},
+    ProgramResult,
 };
 use pinocchio_system::instructions::{Allocate, Assign, CreateAccount, Transfer};
 
 use crate::{
     state::{Class, OwnerType, Record},
-    utils::{ByteReader, Context},
+    utils::{hashv, ByteReader, Context},
 };
 
 /// CreateRecord instruction.
@@ -65,17 +69,22 @@ impl<'info> TryFrom<&'info [AccountInfo]> for CreateRecordAccounts<'info> {
 }
 
 const EXPIRY_OFFSET: usize = 0;
-const SEED_LEN_OFFSET: usize = EXPIRY_OFFSET + size_of::<i64>();
+const NAME_LEN_OFFSET: usize = EXPIRY_OFFSET + size_of::<i64>();
+const RECORD_NAME_HASH_PREFIX: &[u8] = b"srs-record-name-v1";
+
+fn hash_record_name(name: &str) -> [u8; 32] {
+    hashv(&[RECORD_NAME_HASH_PREFIX, name.as_bytes()])
+}
 
 pub struct CreateRecord<'info> {
     accounts: CreateRecordAccounts<'info>,
     expiry: i64,
-    seed: &'info [u8],
+    name: &'info str,
     data: &'info str,
 }
 
 /// Minimum length of instruction data required for CreateRecord
-pub const CREATE_RECORD_MIN_IX_LENGTH: usize = size_of::<u8>() * 2;
+pub const CREATE_RECORD_MIN_IX_LENGTH: usize = size_of::<i64>() + size_of::<u16>();
 
 impl<'info> TryFrom<Context<'info>> for CreateRecord<'info> {
     type Error = ProgramError;
@@ -97,15 +106,16 @@ impl<'info> TryFrom<Context<'info>> for CreateRecord<'info> {
 
         // Deserialize variable length data
         let mut variable_data: ByteReader<'info> =
-            ByteReader::new_with_offset(ctx.data, SEED_LEN_OFFSET);
+            ByteReader::new_with_offset(ctx.data, NAME_LEN_OFFSET);
 
-        // Deserialize `seed`
-        let seed: &[u8] = variable_data.read_bytes_with_length()?;
-
-        #[cfg(not(feature = "perf"))]
-        if seed.len() > MAX_SEED_LEN {
-            return Err(ProgramError::InvalidArgument);
-        }
+        // Deserialize `name`
+        let name_len = u16::from_le_bytes(
+            variable_data
+                .read_bytes(size_of::<u16>())?
+                .try_into()
+                .map_err(|_| ProgramError::InvalidInstructionData)?,
+        );
+        let name = variable_data.read_str(name_len as usize)?;
 
         // Deserialize `data`
         let data: &str = variable_data.read_str(variable_data.remaining_bytes())?;
@@ -113,7 +123,7 @@ impl<'info> TryFrom<Context<'info>> for CreateRecord<'info> {
         Ok(Self {
             accounts,
             expiry,
-            seed,
+            name,
             data,
         })
     }
@@ -127,20 +137,25 @@ impl<'info> CreateRecord<'info> {
     }
 
     pub fn execute(&self) -> ProgramResult {
-        let space = Record::MINIMUM_RECORD_SIZE + self.seed.len() + self.data.len();
+        let space = Record::MINIMUM_RECORD_SIZE + self.name.len() + self.data.len();
         let rent = Rent::get()?.minimum_balance(space);
         let lamports = rent.saturating_sub(self.accounts.record.lamports());
 
-        let seeds = [b"record", self.accounts.class.key().as_ref(), self.seed];
+        let name_hash = hash_record_name(self.name);
+        let seeds = [
+            b"record" as &[u8],
+            self.accounts.class.key().as_ref(),
+            name_hash.as_ref(),
+        ];
 
-        let bump: [u8; 1] = [try_find_program_address(&seeds, &crate::ID)
+        let bump = [try_find_program_address(&seeds, &crate::ID)
             .ok_or(ProgramError::InvalidArgument)?
             .1];
 
         let seeds = [
             Seed::from(b"record"),
             Seed::from(self.accounts.class.key()),
-            Seed::from(self.seed),
+            Seed::from(name_hash.as_ref()),
             Seed::from(&bump),
         ];
 
@@ -177,7 +192,7 @@ impl<'info> CreateRecord<'info> {
                 owner: &crate::ID,
             }
             .invoke_signed(&signers)?;
-        }    
+        }
 
         let record = Record {
             class: *self.accounts.class.key(),
@@ -185,7 +200,7 @@ impl<'info> CreateRecord<'info> {
             owner: *self.accounts.owner.key(),
             is_frozen: false,
             expiry: self.expiry,
-            seed: self.seed,
+            name: self.name,
             data: self.data,
         };
 

--- a/program/src/state/record.rs
+++ b/program/src/state/record.rs
@@ -1,9 +1,13 @@
 use crate::{
-    token2022::{CloseAccount, Mint, Token}, utils::{resize_account, ByteWriter}
+    token2022::{CloseAccount, Mint, Token},
+    utils::{resize_account, ByteWriter},
 };
 use core::{mem::size_of, str};
 use pinocchio::{
-    account_info::{AccountInfo, Ref, RefMut}, instruction::{Seed, Signer}, program_error::ProgramError, pubkey::{try_find_program_address, Pubkey}
+    account_info::{AccountInfo, Ref, RefMut},
+    instruction::{Seed, Signer},
+    program_error::ProgramError,
+    pubkey::{try_find_program_address, Pubkey},
 };
 
 use super::{Class, IS_PERMISSIONED_OFFSET};
@@ -15,8 +19,8 @@ const OWNER_TYPE_OFFSET: usize = CLASS_OFFSET + size_of::<Pubkey>();
 pub const OWNER_OFFSET: usize = OWNER_TYPE_OFFSET + size_of::<u8>();
 pub const IS_FROZEN_OFFSET: usize = OWNER_OFFSET + size_of::<Pubkey>();
 const EXPIRY_OFFSET: usize = IS_FROZEN_OFFSET + size_of::<bool>();
-const SEED_LEN_OFFSET: usize = EXPIRY_OFFSET + size_of::<i64>();
-pub const SEED_OFFSET: usize = SEED_LEN_OFFSET + size_of::<u8>();
+const NAME_LEN_OFFSET: usize = EXPIRY_OFFSET + size_of::<i64>();
+pub const NAME_OFFSET: usize = NAME_LEN_OFFSET + size_of::<u16>();
 
 #[repr(C)]
 pub struct Record<'info> {
@@ -31,7 +35,7 @@ pub struct Record<'info> {
     /// Optional expiration timestamp, if not set, the expiry is [0; 8]
     pub expiry: i64,
     /// The record name/key
-    pub seed: &'info [u8],
+    pub name: &'info str,
     /// The record's data content
     pub data: &'info str,
 }
@@ -56,7 +60,25 @@ impl<'info> Record<'info> {
         + size_of::<Pubkey>()
         + size_of::<bool>()
         + size_of::<i64>()
-        + size_of::<u8>();
+        + size_of::<u16>();
+
+    fn get_data_offset(data: &[u8]) -> Result<usize, ProgramError> {
+        let name_len = u16::from_le_bytes(
+            data.get(NAME_LEN_OFFSET..NAME_OFFSET)
+                .ok_or(ProgramError::InvalidAccountData)?
+                .try_into()
+                .map_err(|_| ProgramError::InvalidAccountData)?,
+        ) as usize;
+        let offset = NAME_OFFSET
+            .checked_add(name_len)
+            .ok_or(ProgramError::InvalidAccountData)?;
+
+        if offset > data.len() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(offset)
+    }
 
     /// Check if the program id and discriminator are valid
     #[inline(always)]
@@ -101,7 +123,7 @@ impl<'info> Record<'info> {
         record: &AccountInfo,
         class: Option<&AccountInfo>,
         authority: &AccountInfo,
-        mint: Option<&AccountInfo>
+        mint: Option<&AccountInfo>,
     ) -> Result<(), ProgramError> {
         // Check the program id and the discriminator
         Self::check_program_id_and_discriminator(record)?;
@@ -112,7 +134,10 @@ impl<'info> Record<'info> {
         if data[OWNER_TYPE_OFFSET].eq(&(OwnerType::Token as u8)) {
             let mint = mint.ok_or(ProgramError::InvalidAccountData)?;
 
-            if mint.key().ne(&data[OWNER_OFFSET..OWNER_OFFSET + size_of::<Pubkey>()]) {
+            if mint
+                .key()
+                .ne(&data[OWNER_OFFSET..OWNER_OFFSET + size_of::<Pubkey>()])
+            {
                 return Err(ProgramError::InvalidAccountData);
             }
 
@@ -122,9 +147,9 @@ impl<'info> Record<'info> {
 
             // Close the Mint and get back the rent
             let bump = [
-            try_find_program_address(&[b"mint", record.key()], &crate::ID)
-                .ok_or(ProgramError::InvalidArgument)?
-                .1,
+                try_find_program_address(&[b"mint", record.key()], &crate::ID)
+                    .ok_or(ProgramError::InvalidArgument)?
+                    .1,
             ];
 
             let seeds = [
@@ -132,9 +157,9 @@ impl<'info> Record<'info> {
                 Seed::from(record.key()),
                 Seed::from(&bump),
             ];
-    
+
             let signers = [Signer::from(&seeds)];
-    
+
             // Close the mint account
             CloseAccount {
                 account: mint,
@@ -161,7 +186,10 @@ impl<'info> Record<'info> {
 
         // Validate the delegate
         let class = class.ok_or(ProgramError::InvalidAccountData)?;
-        if class.key().ne(&data[CLASS_OFFSET..CLASS_OFFSET + size_of::<Pubkey>()]) {
+        if class
+            .key()
+            .ne(&data[CLASS_OFFSET..CLASS_OFFSET + size_of::<Pubkey>()])
+        {
             return Err(ProgramError::InvalidAccountData);
         }
 
@@ -199,7 +227,10 @@ impl<'info> Record<'info> {
 
         // Validate the delegate
         let class = class.ok_or(ProgramError::MissingRequiredSignature)?;
-        if class.key().ne(&data[CLASS_OFFSET..CLASS_OFFSET + size_of::<Pubkey>()]) {
+        if class
+            .key()
+            .ne(&data[CLASS_OFFSET..CLASS_OFFSET + size_of::<Pubkey>()])
+        {
             return Err(ProgramError::InvalidAccountData);
         }
 
@@ -262,7 +293,10 @@ impl<'info> Record<'info> {
 
         // Validate the delegate
         let class = class.ok_or(ProgramError::InvalidAccountData)?;
-        if class.key().ne(&record_data[CLASS_OFFSET..CLASS_OFFSET + size_of::<Pubkey>()]) {
+        if class
+            .key()
+            .ne(&record_data[CLASS_OFFSET..CLASS_OFFSET + size_of::<Pubkey>()])
+        {
             return Err(ProgramError::InvalidAccountData);
         }
 
@@ -345,7 +379,8 @@ impl<'info> Record<'info> {
         }
 
         // Update the expiry
-        data[EXPIRY_OFFSET..EXPIRY_OFFSET + size_of::<i64>()].clone_from_slice(&new_expiry.to_le_bytes());
+        data[EXPIRY_OFFSET..EXPIRY_OFFSET + size_of::<i64>()]
+            .clone_from_slice(&new_expiry.to_le_bytes());
 
         Ok(())
     }
@@ -359,14 +394,15 @@ impl<'info> Record<'info> {
         payer: &'info AccountInfo,
         data: &'info str,
     ) -> Result<(), ProgramError> {
-        let seed_len = {
+        let offset = {
             let data_ref = record.try_borrow_data()?;
-            data_ref[SEED_LEN_OFFSET] as usize
+            Self::get_data_offset(&data_ref)?
         };
 
-        let offset = seed_len + SEED_LEN_OFFSET + size_of::<u8>();
         let current_len = record.data_len();
-        let new_len = offset + data.len();
+        let new_len = offset
+            .checked_add(data.len())
+            .ok_or(ProgramError::InvalidAccountData)?;
 
         if new_len != current_len {
             resize_account(record, payer, new_len, new_len < current_len)?;
@@ -411,13 +447,14 @@ impl<'info> Record<'info> {
     pub unsafe fn get_metadata_len_unchecked(
         data: &'info Ref<'info, [u8]>,
     ) -> Result<usize, ProgramError> {
-        let mut offset = SEED_LEN_OFFSET + size_of::<u8>() + data[SEED_LEN_OFFSET] as usize;
+        let metadata_start = Self::get_data_offset(data)?;
+        let mut offset = metadata_start;
 
-        // Read seed_len and skip name
-        let seed_len =
+        // Read name_len and skip name
+        let name_len =
             u32::from_le_bytes(data[offset..offset + size_of::<u32>()].try_into().unwrap())
                 as usize;
-        offset += size_of::<u32>() + seed_len;
+        offset += size_of::<u32>() + name_len;
 
         // Read ticker_len and skip ticker
         let ticker_len =
@@ -448,7 +485,7 @@ impl<'info> Record<'info> {
             offset += size_of::<u32>() + value_len;
         }
 
-        Ok(offset - (SEED_LEN_OFFSET - size_of::<u8>() - data[SEED_LEN_OFFSET] as usize))
+        Ok(offset - metadata_start)
     }
 
     #[inline(always)]
@@ -458,13 +495,14 @@ impl<'info> Record<'info> {
     pub unsafe fn get_metadata_data_unchecked(
         data: &'info Ref<'info, [u8]>,
     ) -> Result<(&'info [u8], Option<&'info [u8]>), ProgramError> {
-        let mut offset = SEED_LEN_OFFSET + size_of::<u8>() + data[SEED_LEN_OFFSET] as usize;
+        let metadata_start = Self::get_data_offset(data)?;
+        let mut offset = metadata_start;
 
-        // Read seed_len and skip seed
-        let seed_len =
+        // Read name_len and skip name
+        let name_len =
             u32::from_le_bytes(data[offset..offset + size_of::<u32>()].try_into().unwrap())
                 as usize;
-        offset += size_of::<u32>() + seed_len;
+        offset += size_of::<u32>() + name_len;
 
         // Read ticker_len and skip ticker
         let ticker_len =
@@ -478,8 +516,7 @@ impl<'info> Record<'info> {
                 as usize;
         offset += size_of::<u32>() + uri_len;
 
-        let metadata_data =
-            &data[SEED_LEN_OFFSET + size_of::<u8>() + data[SEED_LEN_OFFSET] as usize..offset];
+        let metadata_data = &data[metadata_start..offset];
 
         let additional_metadata_data =
             if u32::from_le_bytes(data[offset..offset + size_of::<u32>()].try_into().unwrap()) != 0
@@ -500,7 +537,7 @@ impl<'info> Record<'info> {
         &self,
         account_info: &'info AccountInfo,
     ) -> Result<(), ProgramError> {
-        let required_space = Self::MINIMUM_RECORD_SIZE + self.seed.len() + self.data.len();
+        let required_space = Self::MINIMUM_RECORD_SIZE + self.name.len() + self.data.len();
         if account_info.data_len() < required_space {
             return Err(ProgramError::InvalidAccountData);
         }
@@ -517,8 +554,14 @@ impl<'info> Record<'info> {
         ByteWriter::write_with_offset(&mut data, IS_FROZEN_OFFSET, self.is_frozen)?;
         ByteWriter::write_with_offset(&mut data, EXPIRY_OFFSET, self.expiry)?;
 
-        let mut variable_data = ByteWriter::new_with_offset(&mut data, SEED_LEN_OFFSET);
-        variable_data.write_bytes_with_length(self.seed)?;
+        let name_len: u16 = self
+            .name
+            .len()
+            .try_into()
+            .map_err(|_| ProgramError::InvalidArgument)?;
+        let mut variable_data = ByteWriter::new_with_offset(&mut data, NAME_LEN_OFFSET);
+        variable_data.write_bytes(&name_len.to_le_bytes())?;
+        variable_data.write_str(self.name)?;
         variable_data.write_str(self.data)?;
 
         Ok(())

--- a/program/src/tests.rs
+++ b/program/src/tests.rs
@@ -1,10 +1,10 @@
 use borsh::de::BorshDeserialize;
 use borsh::ser::BorshSerialize;
-use core::str::FromStr;
+use core::{mem::size_of, str::FromStr};
 use solana_account::{Account, WritableAccount};
 use solana_program::program_error::ProgramError;
 
-use kaigan::types::{RemainderStr, RemainderVec, U8PrefixString, U8PrefixVec};
+use kaigan::types::{RemainderStr, RemainderVec, U16PrefixString, U8PrefixString};
 use mollusk_svm::{program::keyed_account_for_system_program, result::Check, Mollusk};
 use solana_pubkey::Pubkey;
 
@@ -12,13 +12,16 @@ use solana_record_service_client::{
     accounts::*,
     instructions::*,
     programs::SOLANA_RECORD_SERVICE_ID,
-    types::{Metadata, AdditionalMetadata},
+    types::{AdditionalMetadata, Metadata},
 };
+
+use crate::utils::hashv;
 
 pub const AUTHORITY: Pubkey = Pubkey::new_from_array([0xaa; 32]);
 pub const OWNER: Pubkey = Pubkey::new_from_array([0xbb; 32]);
 pub const NEW_OWNER: Pubkey = Pubkey::new_from_array([0xcc; 32]);
 pub const RANDOM_PUBKEY: Pubkey = Pubkey::new_from_array([0xdd; 32]);
+const RECORD_NAME_HASH_PREFIX: &[u8] = b"srs-record-name-v1";
 
 // TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
 pub const TOKEN_2022_PROGRAM_ID: Pubkey = Pubkey::new_from_array([
@@ -71,8 +74,19 @@ fn make_u8prefix_string(s: &str) -> U8PrefixString {
         .expect("Invalid name")
 }
 
-fn make_u8prefix_vec_u8(s: &[u8]) -> U8PrefixVec<u8> {
-    U8PrefixVec::try_from_slice(&[&[s.len() as u8], s].concat()).expect("Invalid seed")
+fn make_u16prefix_string(s: &str) -> U16PrefixString {
+    let len = u16::try_from(s.len()).expect("Name is too long");
+    U16PrefixString::try_from_slice(&[&len.to_le_bytes(), s.as_bytes()].concat())
+        .expect("Invalid name")
+}
+
+fn find_record_address(class: &Pubkey, name: &str) -> Pubkey {
+    let name_hash = hashv(&[RECORD_NAME_HASH_PREFIX, name.as_bytes()]);
+    Pubkey::find_program_address(
+        &[b"record", class.as_ref(), name_hash.as_ref()],
+        &SOLANA_RECORD_SERVICE_ID,
+    )
+    .0
 }
 
 fn make_u32prefix_string(s: &str) -> String {
@@ -158,13 +172,10 @@ fn keyed_account_for_record(
     owner: Pubkey,
     is_frozen: bool,
     expiry: i64,
-    seed: &[u8],
+    name: &str,
     data: &[u8],
 ) -> (Pubkey, Account) {
-    let (address, _bump) = Pubkey::find_program_address(
-        &[b"record", &class.as_ref(), seed.as_ref()],
-        &SOLANA_RECORD_SERVICE_ID,
-    );
+    let address = find_record_address(&class, name);
     let record_account_data = Record {
         discriminator: 2,
         class,
@@ -172,7 +183,7 @@ fn keyed_account_for_record(
         owner,
         is_frozen,
         expiry,
-        seed: make_u8prefix_vec_u8(seed),
+        name: make_u16prefix_string(name),
         data: RemainderVec::<u8>::try_from_slice(data).unwrap(),
     }
     .try_to_vec()
@@ -209,10 +220,7 @@ fn keyed_account_for_record_with_metadata(
     name: &str,
     metadata: Option<&[u8]>,
 ) -> (Pubkey, Account) {
-    let (address, _bump) = Pubkey::find_program_address(
-        &[b"record", &class.as_ref(), name.as_ref()],
-        &SOLANA_RECORD_SERVICE_ID,
-    );
+    let address = find_record_address(&class, name);
     let record_account_data = Record {
         discriminator: 2,
         class,
@@ -220,7 +228,7 @@ fn keyed_account_for_record_with_metadata(
         owner,
         is_frozen,
         expiry,
-        seed: make_u8prefix_vec_u8(name.as_bytes()),
+        name: make_u16prefix_string(name),
         data: RemainderVec::<u8>::try_from_slice(metadata.unwrap_or(METADATA)).unwrap(),
     }
     .try_to_vec()
@@ -258,10 +266,7 @@ fn keyed_account_for_record_with_metadata_and_additional_metadata(
     expiry: i64,
     name: &str,
 ) -> (Pubkey, Account) {
-    let (address, _bump) = Pubkey::find_program_address(
-        &[b"record", &class.as_ref(), name.as_ref()],
-        &SOLANA_RECORD_SERVICE_ID,
-    );
+    let address = find_record_address(&class, name);
     let record_account_data = Record {
         discriminator: 2,
         class,
@@ -269,7 +274,7 @@ fn keyed_account_for_record_with_metadata_and_additional_metadata(
         owner,
         is_frozen,
         expiry,
-        seed: make_u8prefix_vec_u8(name.as_bytes()),
+        name: make_u16prefix_string(name),
         data: RemainderVec::<u8>::try_from_slice(METADATA_WITH_ADDITIONAL_METADATA).unwrap(),
     }
     .try_to_vec()
@@ -302,10 +307,7 @@ fn keyed_account_for_record_with_metadata_and_multiple_additional_metadata(
     expiry: i64,
     name: &str,
 ) -> (Pubkey, Account) {
-    let (address, _bump) = Pubkey::find_program_address(
-        &[b"record", &class.as_ref(), name.as_ref()],
-        &SOLANA_RECORD_SERVICE_ID,
-    );
+    let address = find_record_address(&class, name);
     let record_account_data = Record {
         discriminator: 2,
         class,
@@ -313,7 +315,7 @@ fn keyed_account_for_record_with_metadata_and_multiple_additional_metadata(
         owner,
         is_frozen,
         expiry,
-        seed: make_u8prefix_vec_u8(name.as_bytes()),
+        name: make_u16prefix_string(name),
         data: RemainderVec::<u8>::try_from_slice(METADATA_WITH_MULTIPLE_ADDITIONAL_METADATA)
             .unwrap(),
     }
@@ -333,54 +335,55 @@ fn keyed_account_for_record_with_metadata_and_multiple_additional_metadata(
 }
 
 const MINT_DATA_WITH_EXTENSIONS: &[u8] = &[
-    1, 0, 0, 0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19, 33,
-    142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0,
-    0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19, 33, 142, 101,
-    42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 1,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
 ];
 const MINT_DATA_WITH_EXTENSIONS_AND_NO_SUPPLY: &[u8] = &[
-    1, 0, 0, 0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19, 33,
-    142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0,
-    0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19, 33, 142, 101,
-    42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 1,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
 ];
 const MINT_CLOSE_AUTHORITY_EXTENSION: &[u8] = &[
-    3, 0, 32, 0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19, 33,
-    142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127,
+    3, 0, 32, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154,
 ];
 const MINT_PERMANENT_DELEGATE_EXTENSION: &[u8] = &[
-    12, 0, 32, 0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19, 33,
-    142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127,
+    12, 0, 32, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154,
 ];
 const MINT_METADATA_POINTER_EXTENSION: &[u8] = &[
-    18, 0, 64, 0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19, 33,
-    142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31,
-    190, 147, 58, 233, 60, 212, 133, 19, 33, 142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127,
+    18, 0, 64, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154, 135, 40, 132, 210, 116, 95,
+    104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165, 23, 50, 110, 159, 251, 80, 242, 78, 11,
+    198, 100, 241, 168, 154,
 ];
 const MINT_GROUP_MEMBER_POINTER_EXTENSION: &[u8] = &[
-    22, 0, 64, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87,
-    188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 44, 183, 51, 50, 60, 76,
-    5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19, 33, 142, 101, 42, 77, 206, 214, 6, 73, 4,
-    96, 81, 27, 127,
+    22, 0, 64, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66,
+    78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 135, 40, 132, 210, 116,
+    95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165, 23, 50, 110, 159, 251, 80, 242, 78,
+    11, 198, 100, 241, 168, 154,
 ];
 const MINT_METADATA_EXTENSION: &[u8] = &[
-    19, 0, 91, 0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19, 33,
-    142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31,
-    190, 147, 58, 233, 60, 212, 133, 19, 33, 142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127,
-    4, 0, 0, 0, 116, 101, 115, 116, 3, 0, 0, 0, 83, 82, 83, 4, 0, 0, 0, 116, 101, 115, 116, 0, 0,
-    0, 0,
+    19, 0, 91, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154, 135, 40, 132, 210, 116, 95,
+    104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165, 23, 50, 110, 159, 251, 80, 242, 78, 11,
+    198, 100, 241, 168, 154, 4, 0, 0, 0, 116, 101, 115, 116, 3, 0, 0, 0, 83, 82, 83, 4, 0, 0, 0,
+    116, 101, 115, 116, 0, 0, 0, 0,
 ];
 const MINT_GROUP_MEMBER_EXTENSION: &[u8] = &[
-    23, 0, 72, 0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19, 33,
-    142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127, 52, 137, 177, 136, 59, 205, 145, 103,
-    193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152,
-    136, 141, 87, 92, 1, 0, 0, 0, 0, 0, 0, 0,
+    23, 0, 72, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154, 128, 169, 86, 118, 238, 211,
+    65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165,
+    142, 112, 195, 163, 78, 34, 1, 0, 0, 0, 0, 0, 0, 0,
 ];
 
 fn keyed_account_for_mint(record: Pubkey) -> (Pubkey, Account) {
@@ -440,17 +443,17 @@ fn keyed_account_for_mint(record: Pubkey) -> (Pubkey, Account) {
 }
 
 const MINT_METADATA_EXTENSION_UPDATED: &[u8] = &[
-    19, 0, 92, 0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19, 33,
-    142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31,
-    190, 147, 58, 233, 60, 212, 133, 19, 33, 142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127,
-    5, 0, 0, 0, 116, 101, 115, 116, 50, 3, 0, 0, 0, 83, 82, 83, 4, 0, 0, 0, 116, 101, 115, 116, 0,
-    0, 0, 0,
+    19, 0, 92, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154, 135, 40, 132, 210, 116, 95,
+    104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165, 23, 50, 110, 159, 251, 80, 242, 78, 11,
+    198, 100, 241, 168, 154, 5, 0, 0, 0, 116, 101, 115, 116, 50, 3, 0, 0, 0, 83, 82, 83, 4, 0, 0,
+    0, 116, 101, 115, 116, 0, 0, 0, 0,
 ];
 const MINT_GROUP_MEMBER_EXTENSION_UPDATED: &[u8] = &[
-    23, 0, 72, 0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19, 33,
-    142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127, 52, 137, 177, 136, 59, 205, 145, 103,
-    193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152,
-    136, 141, 87, 92, 2, 0, 0, 0, 0, 0, 0, 0,
+    23, 0, 72, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154, 128, 169, 86, 118, 238, 211,
+    65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165,
+    142, 112, 195, 163, 78, 34, 2, 0, 0, 0, 0, 0, 0, 0,
 ];
 
 fn keyed_account_for_updated_mint(record: Pubkey) -> (Pubkey, Account) {
@@ -510,11 +513,11 @@ fn keyed_account_for_updated_mint(record: Pubkey) -> (Pubkey, Account) {
 }
 
 const MINT_METADATA_EXTENSION_WITH_ADDITIONAL_METADATA: &[u8; 111] = &[
-    19, 0, 107, 0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19,
-    33, 142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127, 44, 183, 51, 50, 60, 76, 5, 80, 101,
-    31, 190, 147, 58, 233, 60, 212, 133, 19, 33, 142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27,
-    127, 4, 0, 0, 0, 116, 101, 115, 116, 3, 0, 0, 0, 83, 82, 83, 4, 0, 0, 0, 116, 101, 115, 116, 1,
-    0, 0, 0, 4, 0, 0, 0, 116, 101, 115, 116, 4, 0, 0, 0, 116, 101, 115, 116,
+    19, 0, 107, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154, 135, 40, 132, 210, 116, 95,
+    104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165, 23, 50, 110, 159, 251, 80, 242, 78, 11,
+    198, 100, 241, 168, 154, 4, 0, 0, 0, 116, 101, 115, 116, 3, 0, 0, 0, 83, 82, 83, 4, 0, 0, 0,
+    116, 101, 115, 116, 1, 0, 0, 0, 4, 0, 0, 0, 116, 101, 115, 116, 4, 0, 0, 0, 116, 101, 115, 116,
 ];
 
 fn keyed_account_for_mint_with_additional_metadata(record: Pubkey) -> (Pubkey, Account) {
@@ -573,13 +576,13 @@ fn keyed_account_for_mint_with_additional_metadata(record: Pubkey) -> (Pubkey, A
 }
 
 const MINT_METADATA_EXTENSIONE_WITH_MULTIPLE_ADDITIONAL_METADATA: &[u8; 143] = &[
-    19, 0, 139, 0, 44, 183, 51, 50, 60, 76, 5, 80, 101, 31, 190, 147, 58, 233, 60, 212, 133, 19,
-    33, 142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27, 127, 44, 183, 51, 50, 60, 76, 5, 80, 101,
-    31, 190, 147, 58, 233, 60, 212, 133, 19, 33, 142, 101, 42, 77, 206, 214, 6, 73, 4, 96, 81, 27,
-    127, 4, 0, 0, 0, 116, 101, 115, 116, 3, 0, 0, 0, 83, 82, 83, 4, 0, 0, 0, 116, 101, 115, 116, 3,
-    0, 0, 0, 4, 0, 0, 0, 116, 101, 115, 116, 4, 0, 0, 0, 116, 101, 115, 116, 4, 0, 0, 0, 115, 101,
-    115, 116, 4, 0, 0, 0, 116, 101, 115, 116, 4, 0, 0, 0, 114, 101, 115, 116, 4, 0, 0, 0, 116, 101,
-    115, 116,
+    19, 0, 139, 0, 135, 40, 132, 210, 116, 95, 104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165,
+    23, 50, 110, 159, 251, 80, 242, 78, 11, 198, 100, 241, 168, 154, 135, 40, 132, 210, 116, 95,
+    104, 6, 159, 22, 88, 87, 149, 183, 141, 42, 74, 165, 23, 50, 110, 159, 251, 80, 242, 78, 11,
+    198, 100, 241, 168, 154, 4, 0, 0, 0, 116, 101, 115, 116, 3, 0, 0, 0, 83, 82, 83, 4, 0, 0, 0,
+    116, 101, 115, 116, 3, 0, 0, 0, 4, 0, 0, 0, 116, 101, 115, 116, 4, 0, 0, 0, 116, 101, 115, 116,
+    4, 0, 0, 0, 115, 101, 115, 116, 4, 0, 0, 0, 116, 101, 115, 116, 4, 0, 0, 0, 114, 101, 115, 116,
+    4, 0, 0, 0, 116, 101, 115, 116,
 ];
 
 fn keyed_account_for_mint_with_multiple_additional_metadata(record: Pubkey) -> (Pubkey, Account) {
@@ -639,25 +642,26 @@ fn keyed_account_for_mint_with_multiple_additional_metadata(record: Pubkey) -> (
 }
 
 const GROUP_MINT_DATA_WITH_EXTENSIONS: &[u8] = &[
-    1, 0, 0, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188,
-    182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-    1, 0, 0, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188,
-    182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78,
+    133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 1, 0, 0, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66,
+    78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
 ];
 const MINT_GROUP_POINTER_EXTENSION: &[u8] = &[
-    20, 0, 64, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87,
-    188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 52, 137, 177, 136, 59,
-    205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211,
-    23, 123, 152, 136, 141, 87, 92,
+    20, 0, 64, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66,
+    78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 128, 169, 86, 118, 238,
+    211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106,
+    165, 142, 112, 195, 163, 78, 34,
 ];
 const MINT_GROUP_EXTENSION: &[u8] = &[
-    21, 0, 80, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87,
-    188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 52, 137, 177, 136, 59,
-    205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211,
-    23, 123, 152, 136, 141, 87, 92, 1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255,
+    21, 0, 80, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66,
+    78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 128, 169, 86, 118, 238,
+    211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106,
+    165, 142, 112, 195, 163, 78, 34, 1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255,
+    255,
 ];
 
 fn keyed_account_for_group(class: Pubkey) -> (Pubkey, Account) {
@@ -762,10 +766,7 @@ fn create_class() {
         metadata: make_remainder_str("test"),
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -805,10 +806,7 @@ fn update_class_metadata() {
         metadata: RemainderStr::from_str("test2").unwrap(),
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -847,10 +845,7 @@ fn update_class_metadata_incorrect_authority() {
         metadata: RemainderStr::from_str("test2").unwrap(),
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -874,20 +869,19 @@ fn update_class_authority() {
     //System Program
     let (system_program, system_program_data) = keyed_account_for_system_program();
 
-    let instruction = UpdateClassAuthority { 
+    let instruction = UpdateClassAuthority {
         authority: authority,
         payer: authority,
         class,
-        system_program, 
-    }.instruction(UpdateClassAuthorityInstructionArgs { new_authority });
+        system_program,
+    }
+    .instruction(UpdateClassAuthorityInstructionArgs { new_authority });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     // Class Updated
-    let (_, class_data_updated) = keyed_account_for_class(new_authority, false, false, "test", "test");
+    let (_, class_data_updated) =
+        keyed_account_for_class(new_authority, false, false, "test", "test");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -898,7 +892,9 @@ fn update_class_authority() {
         ],
         &[
             Check::success(),
-            Check::account(&class).data(&class_data_updated.data).build(),
+            Check::account(&class)
+                .data(&class_data_updated.data)
+                .build(),
         ],
     );
 }
@@ -915,10 +911,7 @@ fn update_class_frozen() {
     let instruction = FreezeClass { authority, class }
         .instruction(FreezeClassInstructionArgs { is_frozen: true });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -942,10 +935,7 @@ fn update_class_frozen_already_frozen() {
     let instruction = FreezeClass { authority, class }
         .instruction(FreezeClassInstructionArgs { is_frozen: true });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -965,7 +955,7 @@ fn create_record() {
     let (class, class_data) = keyed_account_for_class_default();
     // Record
     let (record, record_data) =
-        keyed_account_for_record(class, 0, owner, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, owner, false, 0, "test", b"test");
     //System Program
     let (system_program, system_program_data) = keyed_account_for_system_program();
 
@@ -979,14 +969,11 @@ fn create_record() {
     }
     .instruction(CreateRecordInstructionArgs {
         expiration: 0,
-        seed: make_u8prefix_vec_u8(b"test"),
+        name: make_u16prefix_string("test"),
         data: make_remainder_vec(b"test"),
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1001,6 +988,102 @@ fn create_record() {
             Check::account(&record).data(&record_data.data).build(),
         ],
     );
+}
+
+#[test]
+fn record_name_hash_vector() {
+    let name_hash = hashv(&[RECORD_NAME_HASH_PREFIX, b"test"]);
+
+    assert_eq!(
+        name_hash.as_ref(),
+        &[
+            0xd4, 0x4e, 0xdb, 0xa0, 0xde, 0x38, 0x6f, 0xc7, 0x1f, 0xec, 0x2b, 0x01, 0x1a, 0x96,
+            0xdd, 0x1a, 0xcc, 0xe9, 0x0c, 0x60, 0x0a, 0xe1, 0x7c, 0x99, 0x30, 0xac, 0x7e, 0x8e,
+            0x16, 0x23, 0x2a, 0x26,
+        ]
+    );
+
+    let hashed_address = find_record_address(&RANDOM_PUBKEY, "test");
+    let raw_name_address = Pubkey::find_program_address(
+        &[b"record", RANDOM_PUBKEY.as_ref(), b"test"],
+        &SOLANA_RECORD_SERVICE_ID,
+    )
+    .0;
+    assert_ne!(hashed_address, raw_name_address);
+}
+
+#[test]
+fn record_layout_uses_u16_utf8_name_prefix() {
+    const NAME_LEN_OFFSET: usize = 75;
+    const NAME_OFFSET: usize = NAME_LEN_OFFSET + size_of::<u16>();
+
+    for name in ["tést".to_owned(), "a".repeat(256)] {
+        let (_, account) =
+            keyed_account_for_record(RANDOM_PUBKEY, 0, OWNER, false, 0, &name, b"record data");
+        let name_len = u16::try_from(name.len()).unwrap();
+
+        assert_eq!(
+            &account.data[NAME_LEN_OFFSET..NAME_OFFSET],
+            &name_len.to_le_bytes()
+        );
+        assert_eq!(
+            &account.data[NAME_OFFSET..NAME_OFFSET + name.len()],
+            name.as_bytes()
+        );
+        assert_eq!(&account.data[NAME_OFFSET + name.len()..], b"record data");
+    }
+}
+
+#[test]
+fn record_decoder_rejects_invalid_utf8_name() {
+    const NAME_LEN_OFFSET: usize = 75;
+    const NAME_OFFSET: usize = NAME_LEN_OFFSET + size_of::<u16>();
+
+    let (_, mut account) = keyed_account_for_record(RANDOM_PUBKEY, 0, OWNER, false, 0, "x", b"");
+    account.data[NAME_LEN_OFFSET..NAME_OFFSET].copy_from_slice(&1_u16.to_le_bytes());
+    account.data[NAME_OFFSET] = 0xff;
+
+    assert!(Record::try_from_slice(&account.data).is_err());
+}
+
+#[test]
+fn create_record_with_variable_length_names() {
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
+
+    for name in ["tést".to_owned(), "a".repeat(256)] {
+        let (owner, owner_data) = keyed_account_for_owner();
+        let (class, class_data) = keyed_account_for_class_default();
+        let (record, record_data) =
+            keyed_account_for_record(class, 0, owner, false, 0, &name, b"test");
+        let (system_program, system_program_data) = keyed_account_for_system_program();
+        let instruction = CreateRecord {
+            owner,
+            payer: owner,
+            class,
+            record,
+            system_program,
+            authority: None,
+        }
+        .instruction(CreateRecordInstructionArgs {
+            expiration: 0,
+            name: make_u16prefix_string(&name),
+            data: make_remainder_vec(b"test"),
+        });
+
+        mollusk.process_and_validate_instruction(
+            &instruction,
+            &[
+                (owner, owner_data),
+                (class, class_data),
+                (record, Account::default()),
+                (system_program, system_program_data),
+            ],
+            &[
+                Check::success(),
+                Check::account(&record).data(&record_data.data).build(),
+            ],
+        );
+    }
 }
 
 #[test]
@@ -1025,7 +1108,7 @@ fn create_record_with_metadata() {
     }
     .instruction(CreateRecordTokenizableInstructionArgs {
         expiration: 0,
-        seed: make_u8prefix_vec_u8(b"test"),
+        name: make_u16prefix_string("test"),
         metadata: Metadata {
             name: make_u32prefix_string("test"),
             symbol: make_u32prefix_string("SRS"),
@@ -1034,10 +1117,7 @@ fn create_record_with_metadata() {
         },
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1077,7 +1157,7 @@ fn create_record_with_metadata_and_additional_metadata() {
     }
     .instruction(CreateRecordTokenizableInstructionArgs {
         expiration: 0,
-        seed: make_u8prefix_vec_u8(b"test"),
+        name: make_u16prefix_string("test"),
         metadata: Metadata {
             name: make_u32prefix_string("test"),
             symbol: make_u32prefix_string("SRS"),
@@ -1089,10 +1169,7 @@ fn create_record_with_metadata_and_additional_metadata() {
         },
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1119,7 +1196,7 @@ fn create_permissioned_record() {
     let (class, class_data) = keyed_account_for_class(AUTHORITY, true, false, "test", "test");
     // Record
     let (record, record_data) =
-        keyed_account_for_record(class, 0, owner, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, owner, false, 0, "test", b"test");
     //System Program
     let (system_program, system_program_data) = keyed_account_for_system_program();
 
@@ -1133,14 +1210,11 @@ fn create_permissioned_record() {
     }
     .instruction(CreateRecordInstructionArgs {
         expiration: 0,
-        seed: make_u8prefix_vec_u8(b"test"),
+        name: make_u16prefix_string("test"),
         data: make_remainder_vec(b"test"),
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1168,10 +1242,10 @@ fn update_record() {
     let (class, class_data) = keyed_account_for_class_default();
     // Record
     let (record, record_data) =
-        keyed_account_for_record(class, 0, OWNER, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, OWNER, false, 0, "test", b"test");
     // Record updated
     let (_, record_data_updated) =
-        keyed_account_for_record(class, 0, OWNER, false, 0, b"test", b"test2");
+        keyed_account_for_record(class, 0, OWNER, false, 0, "test", b"test2");
 
     //System Program
     let (system_program, system_program_data) = keyed_account_for_system_program();
@@ -1187,10 +1261,7 @@ fn update_record() {
         data: make_remainder_vec(b"test2"),
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1220,7 +1291,7 @@ fn update_record_with_metadata() {
     let (class, class_data) = keyed_account_for_class_default();
     // Record
     let (record, record_data) =
-        keyed_account_for_record(class, 0, OWNER, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, OWNER, false, 0, "test", b"test");
 
     // New metadata
     let new_metadata = Metadata {
@@ -1259,10 +1330,7 @@ fn update_record_with_metadata() {
         },
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1293,7 +1361,7 @@ fn update_record_with_delegate_incorrect_authority() {
     let (class, class_data) = keyed_account_for_class(AUTHORITY, true, false, "test", "test");
     // Record
     let (record, record_data) =
-        keyed_account_for_record(class, 0, OWNER, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, OWNER, false, 0, "test", b"test");
 
     //System Program
     let (system_program, system_program_data) = keyed_account_for_system_program();
@@ -1309,10 +1377,7 @@ fn update_record_with_delegate_incorrect_authority() {
         data: make_remainder_vec(b"test2"),
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1337,7 +1402,7 @@ fn update_class_expiry() {
     let (class, class_data) = keyed_account_for_class(AUTHORITY, true, false, "test", "test");
     // Record
     let (record, record_data) =
-        keyed_account_for_record(class, 0, OWNER, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, OWNER, false, 0, "test", b"test");
     //System Program
     let (system_program, system_program_data) = keyed_account_for_system_program();
 
@@ -1348,17 +1413,13 @@ fn update_class_expiry() {
         class,
         system_program,
     }
-    .instruction(UpdateRecordExpiryInstructionArgs {
-        expiry: 1000,
-    });
+    .instruction(UpdateRecordExpiryInstructionArgs { expiry: 1000 });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     // Record updated
-    let (_, record_data_updated) = keyed_account_for_record(class, 0, OWNER, false, 1000, b"test", b"test");
+    let (_, record_data_updated) =
+        keyed_account_for_record(class, 0, OWNER, false, 1000, "test", b"test");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1386,10 +1447,10 @@ fn transfer_record() {
     let (class, _class_data) = keyed_account_for_class_default();
     // Record
     let (record, record_data) =
-        keyed_account_for_record(class, 0, owner, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, owner, false, 0, "test", b"test");
     // Record updated
     let (_, record_data_updated) =
-        keyed_account_for_record(class, 0, NEW_OWNER, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, NEW_OWNER, false, 0, "test", b"test");
 
     let instruction = TransferRecord {
         authority: owner,
@@ -1400,10 +1461,7 @@ fn transfer_record() {
         new_owner: Pubkey::new_from_array([0xcc; 32]),
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1425,10 +1483,10 @@ fn transfer_record_with_delegate() {
     let (class, class_data) = keyed_account_for_class(authority, true, false, "test", "test");
     // Record
     let (record, record_data) =
-        keyed_account_for_record(class, 0, OWNER, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, OWNER, false, 0, "test", b"test");
     // Record updated
     let (_, record_data_updated) =
-        keyed_account_for_record(class, 0, NEW_OWNER, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, NEW_OWNER, false, 0, "test", b"test");
 
     let instruction = TransferRecord {
         authority,
@@ -1439,10 +1497,7 @@ fn transfer_record_with_delegate() {
         new_owner: Pubkey::new_from_array([0xcc; 32]),
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1468,8 +1523,7 @@ fn fail_transfer_record_frozen() {
     // Class
     let (class, _class_data) = keyed_account_for_class_default();
     // Record
-    let (record, record_data) =
-        keyed_account_for_record(class, 0, OWNER, true, 0, b"test", b"test");
+    let (record, record_data) = keyed_account_for_record(class, 0, OWNER, true, 0, "test", b"test");
 
     let instruction = TransferRecord {
         authority: owner,
@@ -1480,10 +1534,7 @@ fn fail_transfer_record_frozen() {
         new_owner: Pubkey::new_from_array([0xcc; 32]),
     });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1502,7 +1553,7 @@ fn delete_record() {
     let (class, _class_data) = keyed_account_for_class_default();
     // Record
     let (record, record_data) =
-        keyed_account_for_record(class, 0, OWNER, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, OWNER, false, 0, "test", b"test");
 
     let instruction = DeleteRecord {
         authority: owner,
@@ -1514,10 +1565,7 @@ fn delete_record() {
     }
     .instruction();
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1543,7 +1591,7 @@ fn delete_record_with_delegate() {
     let (class, class_data) = keyed_account_for_class(authority, true, false, "test", "test");
     // Record
     let (record, record_data) =
-        keyed_account_for_record(class, 0, OWNER, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, OWNER, false, 0, "test", b"test");
 
     let instruction = DeleteRecord {
         authority,
@@ -1555,10 +1603,7 @@ fn delete_record_with_delegate() {
     }
     .instruction();
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1582,18 +1627,16 @@ fn delete_tokenized_record_with_no_supply() {
     // Class
     let (class, _) = keyed_account_for_class_default();
     // Mint
-    let (record, _bump) = Pubkey::find_program_address(
-        &[b"record", &class.as_ref(), b"test"],
-        &SOLANA_RECORD_SERVICE_ID,
-    );
+    let record = find_record_address(&class, "test");
     let (mint, mut mint_data) = keyed_account_for_mint(record);
-    mint_data.data_as_mut_slice()[..MINT_DATA_WITH_EXTENSIONS_AND_NO_SUPPLY.len()].copy_from_slice(MINT_DATA_WITH_EXTENSIONS_AND_NO_SUPPLY);
+    mint_data.data_as_mut_slice()[..MINT_DATA_WITH_EXTENSIONS_AND_NO_SUPPLY.len()]
+        .copy_from_slice(MINT_DATA_WITH_EXTENSIONS_AND_NO_SUPPLY);
     // Record
-    let (_, record_data) =
-        keyed_account_for_record(class, 1, mint, false, 0, b"test", b"test");
+    let (_, record_data) = keyed_account_for_record(class, 1, mint, false, 0, "test", b"test");
     // Token2022 Program
-    let (token2022_program, token2022_program_data) = mollusk_svm_programs_token::token2022::keyed_account();
-   
+    let (token2022_program, token2022_program_data) =
+        mollusk_svm_programs_token::token2022::keyed_account();
+
     let instruction = DeleteRecord {
         authority: owner,
         payer: owner,
@@ -1604,10 +1647,7 @@ fn delete_tokenized_record_with_no_supply() {
     }
     .instruction();
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
 
@@ -1635,10 +1675,10 @@ fn freeze_record() {
     let (class, class_data) = keyed_account_for_class_default();
     // Record
     let (record, record_data) =
-        keyed_account_for_record(class, 0, OWNER, false, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, OWNER, false, 0, "test", b"test");
     // Record frozen
     let (_, record_data_frozen) =
-        keyed_account_for_record(class, 0, OWNER, true, 0, b"test", b"test");
+        keyed_account_for_record(class, 0, OWNER, true, 0, "test", b"test");
 
     let instruction = FreezeRecord {
         authority,
@@ -1647,47 +1687,7 @@ fn freeze_record() {
     }
     .instruction(FreezeRecordInstructionArgs { is_frozen: true });
 
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
-
-    mollusk.process_and_validate_instruction(
-        &instruction,
-        &[(authority, authority_data), (record, record_data), (class, class_data)],
-        &[
-            Check::success(),
-            Check::account(&record)
-                .data(&record_data_frozen.data)
-                .build(),
-        ],
-    );
-}
-
-#[test]
-fn freeze_record_already_frozen() {
-    // Authority
-    let (authority, authority_data) = keyed_account_for_authority();
-    // Class
-    let (class, class_data) = keyed_account_for_class(authority, true, false, "test", "test");
-    // Record
-    let (record, record_data) =
-        keyed_account_for_record(class, 0, OWNER, true, 0, b"test", b"test");
-    // Record frozen
-    let (_, record_data_frozen) =
-        keyed_account_for_record(class, 0, OWNER, true, 0, b"test", b"test");
-
-    let instruction = FreezeRecord {
-        authority,
-        record,
-        class,
-    }
-    .instruction(FreezeRecordInstructionArgs { is_frozen: true });
-
-    let mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk.process_and_validate_instruction(
         &instruction,
@@ -1705,8 +1705,45 @@ fn freeze_record_already_frozen() {
     );
 }
 
-// `[1, 0, 0, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 20, 0, 64, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 21, 0, 80, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 1, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0]`,
-// `[1, 0, 0, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 20, 0, 64, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 21, 0, 80, 0, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 52, 137, 177, 136, 59, 205, 145, 103, 193, 194, 30, 23, 233, 253, 189, 51, 87, 188, 182, 87, 172, 35, 137, 100, 211, 23, 123, 152, 136, 141, 87, 92, 1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255]`
+#[test]
+fn freeze_record_already_frozen() {
+    // Authority
+    let (authority, authority_data) = keyed_account_for_authority();
+    // Class
+    let (class, class_data) = keyed_account_for_class(authority, true, false, "test", "test");
+    // Record
+    let (record, record_data) = keyed_account_for_record(class, 0, OWNER, true, 0, "test", b"test");
+    // Record frozen
+    let (_, record_data_frozen) =
+        keyed_account_for_record(class, 0, OWNER, true, 0, "test", b"test");
+
+    let instruction = FreezeRecord {
+        authority,
+        record,
+        class,
+    }
+    .instruction(FreezeRecordInstructionArgs { is_frozen: true });
+
+    let mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
+
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (authority, authority_data),
+            (record, record_data),
+            (class, class_data),
+        ],
+        &[
+            Check::success(),
+            Check::account(&record)
+                .data(&record_data_frozen.data)
+                .build(),
+        ],
+    );
+}
+
+// `[1, 0, 0, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 20, 0, 64, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 21, 0, 80, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 1, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0]`,
+// `[1, 0, 0, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 20, 0, 64, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 21, 0, 80, 0, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 128, 169, 86, 118, 238, 211, 65, 152, 41, 186, 76, 253, 201, 171, 166, 204, 66, 78, 133, 219, 234, 175, 201, 130, 106, 165, 142, 112, 195, 163, 78, 34, 1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255]`
 
 #[test]
 fn mint_record_token() {
@@ -1744,10 +1781,7 @@ fn mint_record_token() {
     }
     .instruction();
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
@@ -1814,10 +1848,7 @@ fn mint_record_token_with_additional_metadata() {
     }
     .instruction();
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
@@ -1885,10 +1916,7 @@ fn mint_record_token_with_multiple_additional_metadata() {
     }
     .instruction();
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
@@ -1956,10 +1984,7 @@ fn mint_record_token_with_delegate() {
     }
     .instruction();
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
@@ -1996,14 +2021,10 @@ fn freeze_tokenized_record() {
     // Class
     let (class, class_data) = keyed_account_for_class_default();
     // Mint
-    let (record_address, _) = Pubkey::find_program_address(
-        &[b"record", &class.as_ref(), b"test"],
-        &SOLANA_RECORD_SERVICE_ID,
-    );
+    let record_address = find_record_address(&class, "test");
     let (mint, mint_data) = keyed_account_for_mint(record_address);
     // Record
-    let (record, record_data) =
-        keyed_account_for_record(class, 1, mint, false, 0, b"test", b"test");
+    let (record, record_data) = keyed_account_for_record(class, 1, mint, false, 0, "test", b"test");
     // ATA
     let (token_account, token_account_data) = keyed_account_for_token(OWNER, mint, false);
     // ATA updated
@@ -2021,10 +2042,7 @@ fn freeze_tokenized_record() {
     }
     .instruction(FreezeTokenizedRecordInstructionArgs { is_frozen: true });
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
@@ -2055,14 +2073,10 @@ fn freeze_tokenized_record_delegate() {
     // Class
     let (class, class_data) = keyed_account_for_class(authority, true, false, "test", "test");
     // Mint
-    let (record_address, _) = Pubkey::find_program_address(
-        &[b"record", &class.as_ref(), b"test"],
-        &SOLANA_RECORD_SERVICE_ID,
-    );
+    let record_address = find_record_address(&class, "test");
     let (mint, mint_data) = keyed_account_for_mint(record_address);
     // Record
-    let (record, record_data) =
-        keyed_account_for_record(class, 1, mint, false, 0, b"test", b"test");
+    let (record, record_data) = keyed_account_for_record(class, 1, mint, false, 0, "test", b"test");
     // ATA
     let (token_account, token_account_data) = keyed_account_for_token(OWNER, mint, false);
     // ATA updated
@@ -2080,10 +2094,7 @@ fn freeze_tokenized_record_delegate() {
     }
     .instruction(FreezeTokenizedRecordInstructionArgs { is_frozen: true });
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
@@ -2114,14 +2125,10 @@ fn transfer_tokenized_record() {
     // Class
     let (class, _class_data) = keyed_account_for_class_default();
     // Mint
-    let (record_address, _) = Pubkey::find_program_address(
-        &[b"record", &class.as_ref(), b"test"],
-        &SOLANA_RECORD_SERVICE_ID,
-    );
+    let record_address = find_record_address(&class, "test");
     let (mint, mint_data) = keyed_account_for_mint(record_address);
     // Record
-    let (record, record_data) =
-        keyed_account_for_record(class, 1, mint, false, 0, b"test", b"test");
+    let (record, record_data) = keyed_account_for_record(class, 1, mint, false, 0, "test", b"test");
     // ATA
     let (token_account, token_account_data) = keyed_account_for_token(owner, mint, false);
     // New ATA
@@ -2141,10 +2148,7 @@ fn transfer_tokenized_record() {
     }
     .instruction();
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
@@ -2170,14 +2174,10 @@ fn transfer_tokenized_record_delegate() {
     // Class
     let (class, class_data) = keyed_account_for_class(authority, true, false, "test", "test");
     // Mint
-    let (record_address, _) = Pubkey::find_program_address(
-        &[b"record", &class.as_ref(), b"test"],
-        &SOLANA_RECORD_SERVICE_ID,
-    );
+    let record_address = find_record_address(&class, "test");
     let (mint, mint_data) = keyed_account_for_mint(record_address);
     // Record
-    let (record, record_data) =
-        keyed_account_for_record(class, 1, mint, false, 0, b"test", b"test");
+    let (record, record_data) = keyed_account_for_record(class, 1, mint, false, 0, "test", b"test");
     // ATA
     let (token_account, token_account_data) = keyed_account_for_token(OWNER, mint, false);
     // New ATA
@@ -2197,10 +2197,7 @@ fn transfer_tokenized_record_delegate() {
     }
     .instruction();
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
@@ -2229,14 +2226,10 @@ fn burn_tokenized_record() {
     // Class
     let (class, _class_data) = keyed_account_for_class_default();
     // Mint
-    let (record_address, _) = Pubkey::find_program_address(
-        &[b"record", &class.as_ref(), b"test"],
-        &SOLANA_RECORD_SERVICE_ID,
-    );
+    let record_address = find_record_address(&class, "test");
     let (mint, mint_data) = keyed_account_for_mint(record_address);
     // Record
-    let (record, record_data) =
-        keyed_account_for_record(class, 1, mint, false, 0, b"test", b"test");
+    let (record, record_data) = keyed_account_for_record(class, 1, mint, false, 0, "test", b"test");
     // ATA
     let (token_account, token_account_data) = keyed_account_for_token(owner, mint, false);
 
@@ -2253,10 +2246,7 @@ fn burn_tokenized_record() {
     }
     .instruction();
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
@@ -2284,14 +2274,10 @@ fn burn_tokenized_record_delegate() {
     // Class
     let (class, class_data) = keyed_account_for_class(authority, true, false, "test", "test");
     // Mint
-    let (record_address, _) = Pubkey::find_program_address(
-        &[b"record", &class.as_ref(), b"test"],
-        &SOLANA_RECORD_SERVICE_ID,
-    );
+    let record_address = find_record_address(&class, "test");
     let (mint, mint_data) = keyed_account_for_mint(record_address);
     // Record
-    let (record, record_data) =
-        keyed_account_for_record(class, 1, mint, false, 0, b"test", b"test");
+    let (record, record_data) = keyed_account_for_record(class, 1, mint, false, 0, "test", b"test");
     // ATA
     let (token_account, token_account_data) = keyed_account_for_token(OWNER, mint, false);
 
@@ -2308,10 +2294,7 @@ fn burn_tokenized_record_delegate() {
     }
     .instruction();
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
@@ -2377,10 +2360,7 @@ fn mint_and_burn_tokenized_record() {
     }
     .instruction();
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
@@ -2455,10 +2435,7 @@ fn mint_and_burn_tokenized_record_delegate() {
     }
     .instruction();
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
@@ -2493,14 +2470,10 @@ fn update_tokenized_record() {
     // Class
     let (class, class_data) = keyed_account_for_class(authority, true, false, "test", "test");
     // Mint
-    let (record_address, _) = Pubkey::find_program_address(
-        &[b"record", &class.as_ref(), b"test"],
-        &SOLANA_RECORD_SERVICE_ID,
-    );
+    let record_address = find_record_address(&class, "test");
     let (mint, mint_data) = keyed_account_for_mint(record_address);
     // Record
-    let (record, record_data) =
-        keyed_account_for_record(class, 1, mint, false, 0, b"test", b"test");
+    let (record, record_data) = keyed_account_for_record(class, 1, mint, false, 0, "test", b"test");
     // ATA
     let (token_account, token_account_data) = keyed_account_for_token(OWNER, mint, false);
     let (token2022, token2022_data) = mollusk_svm_programs_token::token2022::keyed_account();
@@ -2581,20 +2554,14 @@ fn update_tokenized_record() {
     }
     .instruction();
 
-    let mut mollusk = Mollusk::new(
-        &SOLANA_RECORD_SERVICE_ID,
-        "../target/deploy/srs",
-    );
+    let mut mollusk = Mollusk::new(&SOLANA_RECORD_SERVICE_ID, "../target/deploy/srs");
 
     mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
     mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
 
     mollusk.process_and_validate_instruction_chain(
         &[
-            (
-                &burn_instruction, 
-                &[Check::success()]
-            ),
+            (&burn_instruction, &[Check::success()]),
             (
                 &update_instruction,
                 &[

--- a/program/src/utils.rs
+++ b/program/src/utils.rs
@@ -6,6 +6,43 @@ use pinocchio::{
     ProgramResult,
 };
 use pinocchio_system::instructions::Transfer;
+
+pub fn hashv(values: &[&[u8]]) -> [u8; 32] {
+    #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
+    {
+        #[cfg(feature = "sha2")]
+        {
+            use sha2::{Digest, Sha256};
+
+            let mut hasher = Sha256::new();
+            for value in values {
+                hasher.update(value);
+            }
+            hasher.finalize().into()
+        }
+
+        #[cfg(not(feature = "sha2"))]
+        {
+            let _ = values;
+            panic!("hashv is only available on native targets with the `sha2` feature enabled")
+        }
+    }
+
+    // Call via a system call to perform the calculation.
+    #[cfg(any(target_os = "solana", target_arch = "bpf"))]
+    {
+        let mut result = [0; 32];
+        unsafe {
+            pinocchio::syscalls::sol_sha256(
+                values.as_ptr().cast(),
+                values.len() as u64,
+                result.as_mut_ptr(),
+            );
+        }
+        result
+    }
+}
+
 pub struct Context<'info> {
     pub accounts: &'info [AccountInfo],
     pub data: &'info [u8],
@@ -54,7 +91,6 @@ macro_rules! nostd_panic_handler {
         }
     };
 }
-
 
 /// Resize an account and handle lamport transfers based on the new size
 ///

--- a/sdk/rust/src/client/accounts/record.rs
+++ b/sdk/rust/src/client/accounts/record.rs
@@ -8,7 +8,7 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use kaigan::types::RemainderVec;
-use kaigan::types::U8PrefixVec;
+use kaigan::types::U16PrefixString;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
@@ -28,7 +28,7 @@ pub struct Record {
     pub owner: Pubkey,
     pub is_frozen: bool,
     pub expiry: i64,
-    pub seed: U8PrefixVec<u8>,
+    pub name: U16PrefixString,
     pub data: RemainderVec<u8>,
 }
 

--- a/sdk/rust/src/client/instructions/create_record.rs
+++ b/sdk/rust/src/client/instructions/create_record.rs
@@ -8,7 +8,7 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use kaigan::types::RemainderVec;
-use kaigan::types::U8PrefixVec;
+use kaigan::types::U16PrefixString;
 
 /// Accounts.
 #[derive(Debug)]
@@ -104,7 +104,7 @@ impl Default for CreateRecordInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRecordInstructionArgs {
     pub expiration: i64,
-    pub seed: U8PrefixVec<u8>,
+    pub name: U16PrefixString,
     pub data: RemainderVec<u8>,
 }
 
@@ -127,7 +127,7 @@ pub struct CreateRecordBuilder {
     system_program: Option<solana_program::pubkey::Pubkey>,
     authority: Option<solana_program::pubkey::Pubkey>,
     expiration: Option<i64>,
-    seed: Option<U8PrefixVec<u8>>,
+    name: Option<U16PrefixString>,
     data: Option<RemainderVec<u8>>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
 }
@@ -180,8 +180,8 @@ impl CreateRecordBuilder {
         self
     }
     #[inline(always)]
-    pub fn seed(&mut self, seed: U8PrefixVec<u8>) -> &mut Self {
-        self.seed = Some(seed);
+    pub fn name(&mut self, name: U16PrefixString) -> &mut Self {
+        self.name = Some(name);
         self
     }
     #[inline(always)]
@@ -221,7 +221,7 @@ impl CreateRecordBuilder {
         };
         let args = CreateRecordInstructionArgs {
             expiration: self.expiration.clone().expect("expiration is not set"),
-            seed: self.seed.clone().expect("seed is not set"),
+            name: self.name.clone().expect("name is not set"),
             data: self.data.clone().expect("data is not set"),
         };
 
@@ -412,7 +412,7 @@ impl<'a, 'b> CreateRecordCpiBuilder<'a, 'b> {
             system_program: None,
             authority: None,
             expiration: None,
-            seed: None,
+            name: None,
             data: None,
             __remaining_accounts: Vec::new(),
         });
@@ -470,8 +470,8 @@ impl<'a, 'b> CreateRecordCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn seed(&mut self, seed: U8PrefixVec<u8>) -> &mut Self {
-        self.instruction.seed = Some(seed);
+    pub fn name(&mut self, name: U16PrefixString) -> &mut Self {
+        self.instruction.name = Some(name);
         self
     }
     #[inline(always)]
@@ -526,7 +526,7 @@ impl<'a, 'b> CreateRecordCpiBuilder<'a, 'b> {
                 .expiration
                 .clone()
                 .expect("expiration is not set"),
-            seed: self.instruction.seed.clone().expect("seed is not set"),
+            name: self.instruction.name.clone().expect("name is not set"),
             data: self.instruction.data.clone().expect("data is not set"),
         };
         let instruction = CreateRecordCpi {
@@ -565,7 +565,7 @@ struct CreateRecordCpiBuilderInstruction<'a, 'b> {
     system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     expiration: Option<i64>,
-    seed: Option<U8PrefixVec<u8>>,
+    name: Option<U16PrefixString>,
     data: Option<RemainderVec<u8>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(

--- a/sdk/rust/src/client/instructions/create_record_tokenizable.rs
+++ b/sdk/rust/src/client/instructions/create_record_tokenizable.rs
@@ -8,7 +8,7 @@
 use crate::types::Metadata;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use kaigan::types::U8PrefixVec;
+use kaigan::types::U16PrefixString;
 
 /// Accounts.
 #[derive(Debug)]
@@ -104,7 +104,7 @@ impl Default for CreateRecordTokenizableInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRecordTokenizableInstructionArgs {
     pub expiration: i64,
-    pub seed: U8PrefixVec<u8>,
+    pub name: U16PrefixString,
     pub metadata: Metadata,
 }
 
@@ -127,7 +127,7 @@ pub struct CreateRecordTokenizableBuilder {
     system_program: Option<solana_program::pubkey::Pubkey>,
     authority: Option<solana_program::pubkey::Pubkey>,
     expiration: Option<i64>,
-    seed: Option<U8PrefixVec<u8>>,
+    name: Option<U16PrefixString>,
     metadata: Option<Metadata>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
 }
@@ -180,8 +180,8 @@ impl CreateRecordTokenizableBuilder {
         self
     }
     #[inline(always)]
-    pub fn seed(&mut self, seed: U8PrefixVec<u8>) -> &mut Self {
-        self.seed = Some(seed);
+    pub fn name(&mut self, name: U16PrefixString) -> &mut Self {
+        self.name = Some(name);
         self
     }
     #[inline(always)]
@@ -221,7 +221,7 @@ impl CreateRecordTokenizableBuilder {
         };
         let args = CreateRecordTokenizableInstructionArgs {
             expiration: self.expiration.clone().expect("expiration is not set"),
-            seed: self.seed.clone().expect("seed is not set"),
+            name: self.name.clone().expect("name is not set"),
             metadata: self.metadata.clone().expect("metadata is not set"),
         };
 
@@ -412,7 +412,7 @@ impl<'a, 'b> CreateRecordTokenizableCpiBuilder<'a, 'b> {
             system_program: None,
             authority: None,
             expiration: None,
-            seed: None,
+            name: None,
             metadata: None,
             __remaining_accounts: Vec::new(),
         });
@@ -470,8 +470,8 @@ impl<'a, 'b> CreateRecordTokenizableCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn seed(&mut self, seed: U8PrefixVec<u8>) -> &mut Self {
-        self.instruction.seed = Some(seed);
+    pub fn name(&mut self, name: U16PrefixString) -> &mut Self {
+        self.instruction.name = Some(name);
         self
     }
     #[inline(always)]
@@ -526,7 +526,7 @@ impl<'a, 'b> CreateRecordTokenizableCpiBuilder<'a, 'b> {
                 .expiration
                 .clone()
                 .expect("expiration is not set"),
-            seed: self.instruction.seed.clone().expect("seed is not set"),
+            name: self.instruction.name.clone().expect("name is not set"),
             metadata: self
                 .instruction
                 .metadata
@@ -569,7 +569,7 @@ struct CreateRecordTokenizableCpiBuilderInstruction<'a, 'b> {
     system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     expiration: Option<i64>,
-    seed: Option<U8PrefixVec<u8>>,
+    name: Option<U16PrefixString>,
     metadata: Option<Metadata>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(

--- a/sdk/ts/src/accounts/record.ts
+++ b/sdk/ts/src/accounts/record.ts
@@ -26,7 +26,9 @@ import {
   i64,
   mapSerializer,
   publicKey as publicKeySerializer,
+  string,
   struct,
+  u16,
   u8,
 } from '@metaplex-foundation/umi/serializers';
 
@@ -39,7 +41,7 @@ export type RecordAccountData = {
   owner: PublicKey;
   isFrozen: boolean;
   expiry: bigint;
-  seed: Uint8Array;
+  name: string;
   data: Uint8Array;
 };
 
@@ -48,7 +50,7 @@ export type RecordAccountDataArgs = {
   owner: PublicKey;
   isFrozen: boolean;
   expiry: number | bigint;
-  seed: Uint8Array;
+  name: string;
   data: Uint8Array;
 };
 
@@ -65,7 +67,7 @@ export function getRecordAccountDataSerializer(): Serializer<
         ['owner', publicKeySerializer()],
         ['isFrozen', bool()],
         ['expiry', i64()],
-        ['seed', bytes({ size: u8() })],
+        ['name', string({ size: u16() })],
         ['data', bytes()],
       ],
       { description: 'RecordAccountData' }
@@ -147,7 +149,7 @@ export function getRecordGpaBuilder(
       owner: PublicKey;
       isFrozen: boolean;
       expiry: number | bigint;
-      seed: Uint8Array;
+      name: string;
       data: Uint8Array;
     }>({
       discriminator: [0, u8()],
@@ -156,7 +158,7 @@ export function getRecordGpaBuilder(
       owner: [34, publicKeySerializer()],
       isFrozen: [66, bool()],
       expiry: [67, i64()],
-      seed: [75, bytes({ size: u8() })],
+      name: [75, string({ size: u16() })],
       data: [null, bytes()],
     })
     .deserializeUsing<Record>((account) => deserializeRecord(account));

--- a/sdk/ts/src/instructions/createRecord.ts
+++ b/sdk/ts/src/instructions/createRecord.ts
@@ -19,7 +19,9 @@ import {
   bytes,
   i64,
   mapSerializer,
+  string,
   struct,
+  u16,
   u8,
 } from '@metaplex-foundation/umi/serializers';
 import {
@@ -36,7 +38,7 @@ export type CreateRecordInstructionAccounts = {
   payer: Signer;
   /** Class account for the record to be created */
   class: PublicKey | Pda;
-  /** Record account to be created */
+  /** Record PDA derived from ["record", class, SHA-256("srs-record-name-v1" || UTF-8(name))] */
   record: PublicKey | Pda;
   /** System Program used to create our record account */
   systemProgram?: PublicKey | Pda;
@@ -48,13 +50,13 @@ export type CreateRecordInstructionAccounts = {
 export type CreateRecordInstructionData = {
   discriminator: number;
   expiration: bigint;
-  seed: Uint8Array;
+  name: string;
   data: Uint8Array;
 };
 
 export type CreateRecordInstructionDataArgs = {
   expiration: number | bigint;
-  seed: Uint8Array;
+  name: string;
   data: Uint8Array;
 };
 
@@ -71,7 +73,7 @@ export function getCreateRecordInstructionDataSerializer(): Serializer<
       [
         ['discriminator', u8()],
         ['expiration', i64()],
-        ['seed', bytes({ size: u8() })],
+        ['name', string({ size: u16() })],
         ['data', bytes()],
       ],
       { description: 'CreateRecordInstructionData' }

--- a/sdk/ts/src/instructions/createRecordTokenizable.ts
+++ b/sdk/ts/src/instructions/createRecordTokenizable.ts
@@ -16,10 +16,11 @@ import {
 } from '@metaplex-foundation/umi';
 import {
   Serializer,
-  bytes,
   i64,
   mapSerializer,
+  string,
   struct,
+  u16,
   u8,
 } from '@metaplex-foundation/umi/serializers';
 import {
@@ -37,7 +38,7 @@ export type CreateRecordTokenizableInstructionAccounts = {
   payer: Signer;
   /** Class account for the record to be created */
   class: PublicKey | Pda;
-  /** Record account to be created */
+  /** Record PDA derived from ["record", class, SHA-256("srs-record-name-v1" || UTF-8(name))] */
   record: PublicKey | Pda;
   /** System Program used to create our record account */
   systemProgram?: PublicKey | Pda;
@@ -49,13 +50,13 @@ export type CreateRecordTokenizableInstructionAccounts = {
 export type CreateRecordTokenizableInstructionData = {
   discriminator: number;
   expiration: bigint;
-  seed: Uint8Array;
+  name: string;
   metadata: Metadata;
 };
 
 export type CreateRecordTokenizableInstructionDataArgs = {
   expiration: number | bigint;
-  seed: Uint8Array;
+  name: string;
   metadata: MetadataArgs;
 };
 
@@ -72,7 +73,7 @@ export function getCreateRecordTokenizableInstructionDataSerializer(): Serialize
       [
         ['discriminator', u8()],
         ['expiration', i64()],
-        ['seed', bytes({ size: u8() })],
+        ['name', string({ size: u16() })],
         ['metadata', getMetadataSerializer()],
       ],
       { description: 'CreateRecordTokenizableInstructionData' }


### PR DESCRIPTION
## Summary

Closes #23.

Replaces the persisted `seed` with a UTF-8 `name` in `Record` account state, allowing clients to decode record names directly without relying on record data for reverse mapping.

## Changes

- Replaced `seed` with `name` across the program, Codama definitions, and generated Rust and TypeScript SDKs.
- Serialized names as UTF-8 strings with a little-endian `u16` length prefix.
- Updated account sizing, data offsets, resizing, and metadata parsing for the new layout.
- Updated record creation instructions to accept `name`.
- Derived record PDAs using:
  `["record", class, SHA-256("srs-record-name-v1" || UTF-8(name))]`
- Added native and on-chain SHA-256 support.
- Added tests for UTF-8 names, names longer than 255 bytes, serialization, decoding, and PDA derivation.

## Testing

Three existing delete-account tests still fail and are outside the scope of this PR. They expect closed accounts to contain tombstone data (`[0xff]`), while platform-tools v1.52 returns an empty closed account.
